### PR TITLE
fix to work with older modules.dep format (bsc #1027636)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -3020,6 +3020,9 @@ sub build_module_list
   for (<$f>) {
     my @i = split;
     $i[0] =~ s/:$//;
+    # older modutils put the full path into modules.dep
+    # so remove the "/lib/modules/VERSION/" part if it exists
+    @i = map { s#^/lib/modules/([^/]+)/##; $_ } @i;
     if($i[0] =~ m#([^/]+)\.ko$#) {
       $kernel->{modules}{$1} = $i[0];
       # resolve module deps


### PR DESCRIPTION
modutils used to put the modules with full path into modules.dep
('/lib/modules/&lt;VERSION>/kernel/fs/xfs/xfs.ko').

Newer versions have just the relative path ('kernel/fs/xfs/xfs.ko').

The patch changes the entries from the old to the new format.