### PR TITLE
choose correct kernel image name for aarch64 (bsc #1158131)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -3804,7 +3804,7 @@ sub get_initrd_modules
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # unpack_kernel_rpms()
 #
-# Unpack al provided kernel packaged in a temporary location.
+# Unpack all provided kernel packages in a temporary location.
 #
 sub unpack_kernel_rpms
 {
@@ -3825,7 +3825,16 @@ sub unpack_kernel_rpms
     die "Couldn't determine kernel version. No kernel package?\n";
   }
 
+  # kernel image names, per architecture
+  #
+  #  aarch64:	Image, Image-*; vmlinux-*
+  #  i586:	vmlinuz, vmlinuz-*; vmlinux-*
+  #  ppc64le:	vmlinux, vmlinux-*
+  #  s390x:	image, image-*; vmlinux-*
+  #  x86_64:	vmlinuz, vmlinuz-*; vmlinux-*
+  #
   $kernel->{image} = (glob "$kernel->{dir}/boot/vmlinuz-*")[0];
+  $kernel->{image} = (glob "$kernel->{dir}/boot/Image-*")[0] if !$kernel->{image};
   $kernel->{image} = (glob "$kernel->{dir}/boot/image-*")[0] if !$kernel->{image};
   $kernel->{image} = (glob "$kernel->{dir}/boot/vmlinux-*")[0] if !$kernel->{image};
 


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1158131

mksusecd does not pick the correct kernel image on aarch64.

## Solution

It's `Image-*`. And add a comment showing the names in our kernel packages.