### PR TITLE
fix product handling with new SLE full media layout

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -4534,15 +4534,20 @@ sub analyze_products
   open my $prod_fd, ">$prod_file" or die "media.1/products: $!\n";
 
   # ... and append any products we found above
+
+  # Exclude all products that are in subdirectories and re-add them as
+  # needed via mkisofs graft points. That's needed as they might be on
+  # different media originally.
+  #
   for (@{$product_db->{list}}) {
-    if(!$_->{include}) {
-      push @{$mkisofs->{exclude}}, $_->{base_dir} if $_->{product_dir};
-      next;
-    }
+    push @{$mkisofs->{exclude}}, $_->{base_dir} if $_->{product_dir};
+
+    next if !$_->{include};
+
     # FIXME: add $label to name?
     print $prod_fd "/$_->{repo_dir} $_->{name} $_->{ver}\n";
     for my $d (@{$_->{dirs}}) {
-      push @{$mkisofs->{grafts}}, "$_->{repo_dir}/$d=$_->{base_dir}/$d" if $_->{repo_dir} ne $_->{product_dir};
+      push @{$mkisofs->{grafts}}, "$_->{repo_dir}/$d=$_->{base_dir}/$d" if $_->{product_dir};
     }
 
     if($opt_enable_repos =~ /^(1|yes|auto|ask)$/i) {

--- a/mksusecd
+++ b/mksusecd
@@ -4546,9 +4546,9 @@ sub analyze_products
 
     # FIXME: add $label to name?
     print $prod_fd "/$_->{repo_dir} $_->{name} $_->{ver}\n";
-    for my $d (@{$_->{dirs}}) {
-      push @{$mkisofs->{grafts}}, "$_->{repo_dir}/$d=$_->{base_dir}/$d" if $_->{product_dir};
-    }
+
+    # include full product dir, not just repo-specific subdirs
+    push @{$mkisofs->{grafts}}, "$_->{product_dir}=$_->{base_dir}" if $_->{product_dir};
 
     if($opt_enable_repos =~ /^(1|yes|auto|ask)$/i) {
       my $ask_user = $opt_enable_repos =~ /^ask$/i;

--- a/mksusecd
+++ b/mksusecd
@@ -4462,26 +4462,20 @@ sub analyze_products
   my $src_idx = 0;
 
   for my $s (@$src) {
-    File::Find::find({
-      wanted => sub {
-        if(m#/media.1/products$#) {
-          # read any product file we find ...
-          if(open my $f, $_) {
-            my @fields;
-            while(my $l = <$f>) {
-              @fields = split /\s/, $l;
-              # ... and for each product definition, analyse it
-              my $ok = check_product($src_idx, $_, @fields) if @fields == 3;
-              # If we find a valid product, skip the source dir (except if it's the first).
-              # Instead, only the product (the repository) is added to the final medium.
-              $s->{skip} = 1 if $ok && $src_idx > 0;
-            }
-            close $f;
-          }
-        }
-      },
-      no_chdir => 1
-    }, $s->{dir});
+    # read top-level products file
+    $_ = "$s->{dir}/media.1/products";
+    if(open my $f, $_) {
+      my @fields;
+      while(my $l = <$f>) {
+        @fields = split /\s/, $l;
+        # ... and for each product definition, analyse it
+        my $ok = check_product($src_idx, $_, @fields) if @fields == 3;
+        # If we find a valid product, skip the source dir (except if it's the first).
+        # Instead, only the product (the repository) is added to the final medium.
+        $s->{skip} = 1 if $ok && $src_idx > 0;
+      }
+      close $f;
+    }
     $src_idx++;
   }
 

--- a/mksusecd
+++ b/mksusecd
@@ -1100,12 +1100,34 @@ sub build_filelist
 {
   my $src = $_[0];
 
-  for my $s (@$src) {
+  # Internally generated files are put into the $tmp_new base directory.
+  # $files holds a database of all files and their locations (their base
+  # directories).
+  #
+  # The aim is that files that come later in the $src list replace earlier
+  # versions. With $tmp_new taking even more precedence.
+  #
+  # At the start of this function $files has already been set up with the
+  # files in $tmp_new.
+  #
+  # So, go through $src in reverse, put new files into $files and exclude
+  # duplicates.
+  #
+  # This does only apply to files, not directories.
+  #
+  for my $s (reverse @$src) {
     File::Find::find({
       wanted => sub {
         if(m#^$s->{dir}/(.+)#) {
-          push @{$mkisofs->{exclude}}, "$files->{$1}/$1" if $files->{$1} && -f "$files->{$1}/$1";
-          $files->{$1} = $s->{dir};
+          my $file_name = $1;
+          if($files->{$file_name}) {
+            if(-f "$s->{dir}/$file_name") {
+              push @{$mkisofs->{exclude}}, "$s->{dir}/$file_name";
+            }
+          }
+          else {
+            $files->{$file_name} = $s->{dir};
+          }
         }
       },
       no_chdir => 1


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1176176
- https://trello.com/c/HoAiJKC4

With the new full media layout, `--include-repos` did not limit the included product and module parts under certain circumstances (i.e. working on an unpacked ISO).

## Fix

There are several parts:

1. look only at the toplevel products file `media.1/products`, not at their conterparts in the product or module subdirectories
1. the newly created products file did not end up on the generated media due to a bug when merging directories
1. products may be on a single medium (as in sle15-sp2) or distributed on several media (as in sle15-sp1)

## Bugs

The created media are (AFAICS) correct. But (sle15-sp2 only):

yast may run into an internall error at startup: `undefined method `license_confirmation_required?'`.

This seems to be triggered when the generated image contains only one product (not counting modules).