### PR TITLE
fix add_on_products.xml handling (bsc#1176379)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -4315,7 +4315,7 @@ sub prepare_addon
 
   $products_xml = new_products_xml($products_xml, "addons/$addon_alias", $addon_name, $addon_alias, $opt_addon_prio);
 
-  if(open my $fh, ">", "$tmp_dir/add_on_products.xml") {
+  if(open my $fh, ">", new_file("add_on_products.xml")) {
     print $fh $products_xml;
     close $fh;
   }
@@ -4560,7 +4560,7 @@ sub analyze_products
     }
   }
 
-  if($products_xml_updated && open my $fh, ">", "$tmp_new/add_on_products.xml") {
+  if($products_xml_updated && open my $fh, ">", new_file("add_on_products.xml")) {
     print $fh $products_xml;
     close $fh;
   }


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1176379#c15

`add_on_products.xml` is used for adding add-ons and for auto-enabling product repositories. Ensure both functions work together.

Otherwise using both `--addon` and `--enable-repos` option at the same time might end up creating a wrong `add_on_products.xml` or make `mksiosfs` fail.

## Solution

`new_file()` does the same as the code it replaces (create the file in a temporary directory) but it also updates the internal database tracking files for the later `mkisofs` call to ensure the correct version of the file is added to the final image.