### PR TITLE
handle .ko.xz modules (bsc#1182573)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -137,6 +137,11 @@ our $LIBEXECDIR = "/usr/lib";
 my @boot_archs = qw ( x86_64 i386 s390x s390 ia64 aarch64 ppc ppc64 ppc64le );
 my $magic_id = "7984fc91-a43f-4e45-bf27-6d3aa08b24cf";
 
+# valid kernel module extensions
+my $kext_regexp = '\.ko(?:\.xz)?';
+my $kext_glob = '.ko{,.xz}';
+my @kext_list = qw ( .ko .ko.xz );
+
 sub usage;
 sub check_root;
 sub show_progress;
@@ -3891,7 +3896,7 @@ sub get_initrd_modules
   File::Find::find({
     wanted => sub {
       return if -l;	# we don't want links
-      if(m#([^/]+)\.ko$#) {
+      if(m#([^/]+)${kext_regexp}$#) {
         $kernel->{initrd_modules}{$1} = 1;
       }
       if(m#/module\.config$#) {
@@ -3973,7 +3978,7 @@ sub build_module_list
 
   for my $m (@opt_kernel_modules) {
     for (split /,/, $m) {
-      s/\.ko$//;
+      s/${kext_regexp}$//;
       if(s/^-//) {
         $mods_remove{$_} = 1;
       }
@@ -3992,13 +3997,13 @@ sub build_module_list
     # older modutils put the full path into modules.dep
     # so remove the "/lib/modules/VERSION/" part if it exists
     @i = map { s#^/lib/modules/([^/]+)/##; $_ } @i;
-    if($i[0] =~ m#([^/]+)\.ko$#) {
+    if($i[0] =~ m#([^/]+)${kext_regexp}$#) {
       $kernel->{modules}{$1} = $i[0];
       # resolve module deps
       if($kernel->{initrd_modules}{$1} && @i > 1) {
         shift @i;
         for my $m (@i) {
-          if($m =~ m#([^/]+)\.ko$#) {
+          if($m =~ m#([^/]+)${kext_regexp}$#) {
             $kernel->{initrd_modules}{$1} = 3 if !$kernel->{initrd_modules}{$1};
           }
         }
@@ -4049,14 +4054,16 @@ sub build_module_list
 
   my %fw;
 
-  for my $m (glob("$kernel->{new_dir}/lib/modules/$kernel->{version}/initrd/*.ko")) {
+  for my $m (glob("$kernel->{new_dir}/lib/modules/$kernel->{version}/initrd/*${kext_glob}")) {
     chomp $m;
+
+    next unless -f $m;
 
     my @l;
     chomp(@l = `modinfo -F firmware $m`);
 
     $m =~ s#.*/##;
-    $m =~ s#.ko$##;
+    $m =~ s#${kext_regexp}$##;
 
     $fw{$m} = [ @l ] if @l;
   }
@@ -4116,7 +4123,11 @@ sub add_modules_to_initrd
     mkdir "$tmp_dir/lib/modules/$kernel->{version}/initrd", 0755;
 
     for (qw (loop squashfs lz4_decompress xxhash zstd_decompress)) {
-      rename "$kernel->{new_dir}/lib/modules/$kernel->{version}/initrd/$_.ko", "$tmp_dir/lib/modules/$kernel->{version}/initrd/$_.ko";
+      for my $ext (@kext_list) {
+        if(-f "$kernel->{new_dir}/lib/modules/$kernel->{version}/initrd/$_$ext") {
+          rename "$kernel->{new_dir}/lib/modules/$kernel->{version}/initrd/$_$ext", "$tmp_dir/lib/modules/$kernel->{version}/initrd/$_$ext";
+        }
+      }
     }
 
     my $err = system "mksquashfs $kernel->{new_dir} $tmp_dir/parts/$p" .


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1182573

With SLE15-SP3 and current Tumbleweed kernel modules are compressed and have a `.ko.xz` extension. Adjust mksusecd to handle these.