### PR TITLE
support tftpboot-installation-<PRODUCT> RPMs as source (jsc#SLE-22669)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -482,9 +482,16 @@ if($opt_create || $opt_list_repos) {
     s#/*$##;
     next if $_ eq "";
     if(-d) {
-      my $d = (<$_/usr/lib/skelcd/*>)[0];
-      if(-d $d ) {
-        push @sources, { dir => $d, real_name => $_, type => 'dir' };
+      my $d_skel = (<$_/usr/lib/skelcd/*>)[0];
+      my $d_tftp = (<$_/usr/share/tftpboot-installation/*>)[0];
+      if(-d $d_skel ) {
+        push @sources, { dir => $d_skel, real_name => $_, type => 'dir' };
+      }
+      elsif(-d $d_tftp ) {
+        # copy only necessary files
+        my $tmp_dir = $tmp->dir();
+        system "cp -r $d_tftp/{EFI,boot} $tmp_dir";
+        push @sources, { dir => $d_tftp, real_name => $_, type => 'dir' };
       }
       else {
         push @sources, { dir => $_, real_name => $_, type => 'dir' };
@@ -503,9 +510,16 @@ if($opt_create || $opt_list_repos) {
         $iso_cnt++;
         my $d_rpm = $tmp->mnt(sprintf("mnt_%04d", $iso_cnt));
         system "rpm2cpio $_ | ( cd $d_rpm ; cpio --quiet -dmiu --no-absolute-filenames 2>/dev/null)";
-        my $d = (<$d_rpm/usr/lib/skelcd/*>)[0];
-        if(-d $d ) {
-          push @sources, { dir => $d, real_name => $_, type => 'dir' };
+        my $d_skel = (<$d_rpm/usr/lib/skelcd/*>)[0];
+        my $d_tftp = (<$d_rpm/usr/share/tftpboot-installation/*>)[0];
+        if(-d $d_skel ) {
+          push @sources, { dir => $d_skel, real_name => $_, type => 'dir' };
+        }
+        elsif(-d $d_tftp ) {
+          # remove unnecessary files
+          unlink "$d_tftp/README";
+          system "rm -r $d_tftp/net";
+          push @sources, { dir => $d_tftp, real_name => $_, type => 'dir' };
         }
         else {
           push @sources, { dir => $d_rpm, real_name => $_, type => 'dir' };

--- a/mksusecd_man.adoc
+++ b/mksusecd_man.adoc
@@ -346,6 +346,7 @@ Sources can be
 
 - existing installation media
 - skelcd-installer-<PRODUCT> packages (RPMs)
+- tftpboot-installation-<PRODUCT> packages (RPMs)
 - additional or modified files that should be added/merged into the image
 
 either as image/RPM file or unpacked into a directory.
@@ -353,8 +354,9 @@ either as image/RPM file or unpacked into a directory.
 The order of sources is important. Files from later sources will replace
 the same files in previous sources.
 
-If you pass a skelcd-installer-<PRODUCT> RPM (or a directory with the same
-layout) - mksusecd will handle these specially and use the relevant parts.
+If you pass a skelcd-installer-<PRODUCT> or tftpboot-installation-<PRODUCT>
+RPM (or a directory with the same layout) - mksusecd will handle these
+specially and extract the relevant parts.
 
 === Hybrid mode notes
 


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/SLE-22669

mksusecd can already use `skelcd-installer-<PRODUCT>` as input source. Handle `tftpboot-installation-<PRODUCT>` in the same way (it contains the same data but in a different location).

The benefit is that  `tftpboot-installation-<PRODUCT>` are available as part of our usual openSUSE/SLE products and are updated regularly. This way you can easily rebuild the openSUSE/SLE installation media with the latest installer updates.

## Example

```
mksusecd --create new.iso openSUSE-Tumbleweed.iso tftpboot-installation-openSUSE-Tumbleweed-x86_64-17.28-1.1.noarch.rpm
```