### PR TITLE
add --volume1 option to allow setting separate labels for both ISO file systems (bsc#1213185)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -250,6 +250,7 @@ my $opt_vendor;
 my $opt_preparer;
 my $opt_application;
 my $opt_volume;
+my $opt_volume1;
 my $opt_no_docs = 1;
 my $opt_loader;
 my $opt_sign = 1;
@@ -339,6 +340,7 @@ GetOptions(
   'defaultrepo=s'    => \$opt_defaultrepo,
   'instsys-in-repo!' => \$opt_instsys_in_repo,
   'volume=s'         => \$opt_volume,
+  'volume1=s'        => \$opt_volume1,
   'vendor=s'         => \$opt_vendor,
   'preparer=s'       => \$opt_preparer,
   'application=s'    => \$opt_application,
@@ -781,6 +783,8 @@ ISO file system related options:
       --vendor VENDOR_ID        Set ISO publisher id to VENDOR_ID.
       --preparer PREPARER_ID    Set ISO data preparer id to PREPARER_ID.
       --application APP_ID      Set ISO application id to APP_ID.
+      --volume1 VOLUME_ID       Specify ISO volume id of the entire image - in case it should differ
+                                from the ISO volume id used for the partition.
 
 General image layout related options:
 
@@ -1644,6 +1648,10 @@ sub rerun_mkisofs
   }
 
   $progress_end = 100;
+
+  if($opt_volume1) {
+    $mkisofs->{options} .= " -V '" . substr($opt_volume1, 0, 32) . "'";
+  }
 
   run_mkisofs;
 }

--- a/mksusecd_man.adoc
+++ b/mksusecd_man.adoc
@@ -189,6 +189,11 @@ Set ISO data preparer id to _PREPARER_ID_.
 *--application*=_APPLICATION_ID_::
 Set ISO application id to _APPLICAION_ID_.
 
+*--volume1*=_VOLUME_ID_::
+Specify ISO volume id of the entire image - in case it should differ
+from the ISO volume id used for the partition. +
+See *Hybrid mode notes* below.
+
 === General image layout related options
 
 *--uefi*::
@@ -381,6 +386,11 @@ holding all data files. When you mount it, you see either an ISO9660 or
 a FAT filesystem. If you need UEFI support this partition becomes
 partition 2 and partition 1 points to the UEFI image. Partition 1 and 2
 don't overlap. In this variant a consistent partition table is written.
+
+Normally the file system of the entire image and the file system of the main partition
+have identical data and meta data. If you need to have separate labels (volume ids) for
+both file system variants you can use the **--volume1** option to set a different label
+to be used for the entire image.
 
 === Signing notes
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1213185

Add option to allow having different ISO fs labels for the main file system and the ISO file system in the partition of a hybrid ISO.