### PR TITLE
handle compressed firmware files (bsc#1214789)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ you can read more about it [here](layout.md).
 
 ## Downloads
 
-Get the latest version from the [openSUSE Build Service](https://software.opensuse.org/package/mksusecd).
+Packages for openSUSE and SLES are built at the [openSUSE Build Service](https://build.opensuse.org). You can grab
+
+- [official releases](https://software.opensuse.org/package/mksusecd) or
+
+- [latest stable versions](https://software.opensuse.org/download/package?project=home:snwint:ports&package=mksusecd)
+  from my [ports](https://build.opensuse.org/package/show/home:snwint:ports/mksusecd) project
 
 ## Blog
 

--- a/mksusecd
+++ b/mksusecd
@@ -4643,17 +4643,31 @@ sub build_module_list
     $fw{$m} = [ @l ] if @l;
   }
 
-  for my $m (sort keys %fw) {
-    for (@{$fw{$m}}) {
-      my $f;
-      $f = "$_" if -f "$kernel->{dir}/$lib_dir/firmware/$_";
-      $f = "$kernel->{version}/$_" if -f "$kernel->{dir}/$lib_dir/firmware/$kernel->{version}/$_";
+  my $kv = $kernel->{version};
+  my $fw_dir = "$kernel->{dir}/$lib_dir/firmware";
 
-      if($f) {
-        system "install -m 644 -D $kernel->{dir}/$lib_dir/firmware/$f $kernel->{new_dir}/$target_lib_dir/firmware/$f";
+  my %fw_ok;
+  my %fw_missing;
+
+  for my $m (sort keys %fw) {
+    for my $fw (@{$fw{$m}}) {
+      my $ok = 0;
+      for my $f (<$fw_dir/$fw $fw_dir/$kv/$fw $fw_dir/$fw.xz $fw_dir/$kv/$fw.xz $fw_dir/$fw.zst $fw_dir/$kv/$fw.zst>) {
+        if(-r $f) {
+          $f =~ s#^$fw_dir/##;
+          system "install -m 644 -D '$fw_dir/$f' '$kernel->{new_dir}/$target_lib_dir/firmware/$f'\n";
+          $fw_ok{$f} = 1;
+          $ok = 1;
+        }
+      }
+      if(!$ok) {
+        $fw_missing{$fw} = 1;
+        print "missing firmware: $fw ($m.ko)\n" if $opt_verbose >= 1;
       }
     }
   }
+
+  printf "kernel firmware: %d/%d files updated\n", scalar(keys %fw_ok), scalar(keys %fw_ok) + scalar(keys %fw_missing);
 
   # print Dumper(\%fw);
 

--- a/mksusecd_man.adoc
+++ b/mksusecd_man.adoc
@@ -624,5 +624,6 @@ Find more usage examples here: https://github.com/openSUSE/mksusecd/blob/master/
 == See Also
 
 - more documentation: `/usr/share/doc/packages/mksusecd` +
+- get latest version: https://github.com/openSUSE/mksusecd?tab=readme-ov-file#downloads +
 - mksusecd web site: https://github.com/openSUSE/mksusecd +
 - openSUSE Build Service: https://build.opensuse.org


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1214789

Tumbleweed and SLE15-SP6 switched to using compressed kernel firmware files in the installation system.