### PR TITLE
deal with systems where /tmp is a symlink (bsc#1221603)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -12,6 +12,7 @@
 
   use File::Temp;
   use strict 'vars';
+  use Cwd 'abs_path';
 
   sub new
   {
@@ -25,7 +26,7 @@
     $x =~ s/(\s+|"|\\|')/_/;
     $x = 'tmp' if$x eq "";
 
-    my $t = File::Temp::tempdir("/tmp/$x.XXXXXXXX", CLEANUP => $save_tmp ? 0 : 1);
+    my $t = File::Temp::tempdir(abs_path("/tmp") . "/$x.XXXXXXXX", CLEANUP => $save_tmp ? 0 : 1);
 
     $self->{base} = $t;
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1221603

If `/tmp` is a symlink, mksusecd won't find temporarily mounted file systems when trying to unmount during cleanup.