### PR TITLE
add verifymedia script to verify correctness of SUSE media

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,14 @@ install: isohybrid doc
 doc:
 	@if [ -x /usr/bin/asciidoctor ] ; then \
 	  asciidoctor -b manpage -a version=$(VERSION) mksusecd_man.adoc ;\
+	  asciidoctor -b manpage -a version=$(VERSION) verifymedia_man.adoc ;\
 	else \
 	  a2x -f manpage -a version=$(VERSION) mksusecd_man.adoc ;\
+	  a2x -f manpage -a version=$(VERSION) verifymedia_man.adoc ;\
 	fi
 # a2x -f docbook -a version=$(VERSION) mksusecd_man.adoc
 # dblatex mksusecd_man.xml
 
 clean:
-	@rm -f *.o isohybrid *~ */*~ mksusecd{.1,_man.xml,_man.pdf}
+	@rm -f *.o isohybrid *~ */*~ mksusecd{.1,_man.xml,_man.pdf} verifymedia{.1,_man.xml,_man.pdf}
 	@rm -rf package

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,16 @@ install: isohybrid doc
 	@cp mksusecd mksusecd.tmp
 	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION = /' mksusecd.tmp
 	@perl -pi -e 's#"(.*)"#"$(LIBDIR)"# if /LIBEXECDIR = /' mksusecd.tmp
+	@cp verifymedia verifymedia.tmp
+	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION = /' verifymedia.tmp
+	@perl -pi -e 's#"(.*)"#"$(LIBDIR)"# if /LIBEXECDIR = /' verifymedia.tmp
 	@cp isozipl isozipl.tmp
 	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION = /' isozipl.tmp
 	install -m 755 -D mksusecd.tmp $(DESTDIR)$(BINDIR)/mksusecd
+	install -m 755 -D verifymedia.tmp $(DESTDIR)$(BINDIR)/verifymedia
 	install -m 755 -D isozipl.tmp $(DESTDIR)$(BINDIR)/isozipl
 	install -m 755 -D isohybrid $(DESTDIR)$(LIBDIR)/mksusecd/isohybrid
-	@rm -f mksusecd.tmp isozipl.tmp
+	@rm -f mksusecd.tmp verifymedia.tmp isozipl.tmp
 
 doc:
 	@if [ -x /usr/bin/asciidoctor ] ; then \

--- a/obs/mksusecd.spec
+++ b/obs/mksusecd.spec
@@ -61,6 +61,7 @@ This is a tool to create SUSE Linux installation ISOs.
 %install
 make DESTDIR=%{buildroot} LIBDIR=%{_libexecdir} BINDIR=%{_bindir} install %{?_smp_mflags}
 install -D -m 644 mksusecd.1 %{buildroot}%{_mandir}/man1/mksusecd.1
+install -D -m 644 verifymedia.1 %{buildroot}%{_mandir}/man1/verifymedia.1
 
 %files
 %defattr(-,root,root)
@@ -68,6 +69,7 @@ install -D -m 644 mksusecd.1 %{buildroot}%{_mandir}/man1/mksusecd.1
 %{_libexecdir}/%{name}
 %doc README* *.md
 %doc %{_mandir}/man1/mksusecd.*
+%doc %{_mandir}/man1/verifymedia.*
 %if %suse_version >= 1500
 %license COPYING*
 %else

--- a/verifymedia
+++ b/verifymedia
@@ -124,8 +124,7 @@ use utf8;
 use Getopt::Long;
 use Digest::MD5;
 use Digest::SHA;
-use File::Find;
-use File::Path;
+use File::Path 'make_path';
 use Cwd 'abs_path';
 
 use Data::Dumper;
@@ -155,10 +154,8 @@ sub chk_treeinfo_arch;
 sub chk_treeinfo_files;
 sub chk_bootinfo;
 
-sub check_root;
 sub susystem;
 sub get_iso9660_info;
-sub unpack_iso_image;
 sub iso_ls;
 sub read_treeinfo;
 sub read_ini;
@@ -166,7 +163,11 @@ sub get_media_style;
 sub get_media_variant;
 sub get_arch;
 sub get_expected_media_layout;
+sub stat_file;
+sub is_dir;
+sub is_file;
 sub read_file;
+sub extract_file;
 sub get_grub_root;
 sub get_archive_type;
 sub unpack_cpiox;
@@ -178,9 +179,7 @@ sub get_root_option_bootloader;
 
 my $opt_save_temp;
 my $opt_verbose = 0;
-my $opt_mount_iso;
 
-my $config;
 my $tmp;
 my $media;
 my $iso9660;
@@ -196,8 +195,6 @@ my $initrd_dir;
 Getopt::Long::Configure("gnu_compat");
 
 GetOptions(
-  'mount-iso'        => \$opt_mount_iso,
-  'no-mount-iso'     => sub { $opt_mount_iso = 0 },
   'save-temp'        => \$opt_save_temp,
   'verbose|v'        => sub { $opt_verbose++ },
   'version'          => sub { print "$VERSION\n"; exit 0 },
@@ -205,19 +202,6 @@ GetOptions(
 ) || usage 1;
 
 $ENV{PATH} = "/usr/bin:/bin:/usr/sbin:/sbin";
-
-if(open my $f, "$ENV{HOME}/.verifymediarc") {
-  while(<$f>) {
-    next if /^\s*#/;
-    if(/^\s*(\S+?)\s*=\s*(.*?)\s*$/) {
-      my $key = $1;
-      my $val = $2;
-      $val =~ s/^\"|\"$//g;
-      $config->{$key} = $val;
-    }
-  }
-  close $f;
-}
 
 $tmp = Tmp::new($opt_save_temp);
 
@@ -230,6 +214,8 @@ die "$src: not readable\n" unless -r _;
 
 ($src_short = $src) =~ s#^.*/##;
 print "Verifying: $src_short\n";
+
+$iso_dir = $tmp->dir('iso');
 
 $iso9660 = get_iso9660_info $src;
 print "- iso header info:\n", Dumper($iso9660) if $opt_verbose >= 2;
@@ -253,8 +239,6 @@ $iso_ls_plain = iso_ls $src;
 $iso_ls_rockridge = iso_ls $src, "rockridge";
 print "- iso file list (rock ridge):\n", Dumper($iso_ls_rockridge) if $opt_verbose >= 2;
 
-$iso_dir = unpack_iso_image $src; 
-
 show
   chk_files_permission($iso_ls_rockridge),
   "all files are world-readable",
@@ -265,13 +249,13 @@ show
   "all files are owned by root",
   "Files on the ISO image should have uid and gid 0.";
 
-$media->{treeinfo} = read_treeinfo $iso_dir;
+$media->{treeinfo} = read_treeinfo;
 print "- .treeinfo:\n", Dumper($media->{treeinfo}) if $media->{treeinfo} && $opt_verbose >= 2;
 
-$media->{style} = get_media_style $iso_dir;
-$media->{variant} = get_media_variant $iso_dir;
-$media->{arch} = get_arch $iso_ls_rockridge, $media->{treeinfo};
-get_expected_media_layout $iso_dir, $media;
+$media->{style} = get_media_style;
+$media->{variant} = get_media_variant;
+$media->{arch} = get_arch;
+get_expected_media_layout $media;
 
 print "- media:\n", Dumper($media) if $opt_verbose >= 2;
 die "failed to detect architecture\n" unless $media->{arch};
@@ -304,116 +288,116 @@ show_conditional
 
 show_conditional
   $media->{treeinfo},
-  chk_treeinfo_files($iso_ls_rockridge, $media),
+  chk_treeinfo_files($media),
   "kernel and initrd referenced in .treeinfo exist",
   "Kernel and initrd referenced in .treeinfo must exist.";
 
 show
-  chk_file_exists($iso_ls_rockridge, $media->{kernel}),
+  chk_file_exists($media->{kernel}),
   "kernel exists",
   "Kernel must exist and have non-zero size.";
 
 show
-  chk_file_exists($iso_ls_rockridge, $media->{initrd}),
+  chk_file_exists($media->{initrd}),
   "initrd exists",
   "Initrd must exist and have non-zero size.";
 
 show_conditional
   $media->{initrd_off},
-  chk_file_exists($iso_ls_rockridge, $media->{initrd_off}),
+  chk_file_exists($media->{initrd_off}),
   "initrd.off exists",
   "initrd.off must exist and have non-zero size.";
 
 show_conditional
   $media->{initrd_siz},
-  chk_file_exists($iso_ls_rockridge, $media->{initrd_siz}),
+  chk_file_exists($media->{initrd_siz}),
   "initrd.siz exists",
   "initrd.siz must exist and have non-zero size.";
 
 show_conditional
   $media->{cd_ikr},
-  chk_file_exists($iso_ls_rockridge, $media->{cd_ikr}),
+  chk_file_exists($media->{cd_ikr}),
   "cd.ikr exists",
   "cd.ikr must exist and have non-zero size.";
 
 show_conditional
   $media->{suse_ins},
-  chk_file_exists($iso_ls_rockridge, $media->{suse_ins}),
+  chk_file_exists($media->{suse_ins}),
   "suse.ins exists",
   "suse.ins must exist and have non-zero size.";
 
 show_conditional
   $media->{isolinux_cfg},
-  chk_file_exists($iso_ls_rockridge, $media->{isolinux_cfg}),
+  chk_file_exists($media->{isolinux_cfg}),
   "isolinux config exists",
   "isolinux.cfg must exist and have non-zero size.";
 
 show_conditional
   $media->{bootinfo_txt},
-  chk_file_exists($iso_ls_rockridge, $media->{bootinfo_txt}),
+  chk_file_exists($media->{bootinfo_txt}),
   "bootinfo config exists",
   "bootinfo.txt must exist and have non-zero size.";
 
 show_conditional
   $media->{bootinfo_txt},
-  chk_bootinfo($iso_dir, $iso_ls_plain, $media),	# use $iso_ls_plain as PowerPC firmware does not understand Rock Ridge extension
+  chk_bootinfo($media),
   "bootinfo config points to grub",
   "boot-script entry in bootinfo.txt must point to grub and\ngrub must have a config file in the same location.";
 
 show_conditional
   $media->{grub_earlyboot_cfg},
-  chk_file_exists($iso_ls_rockridge, $media->{grub_earlyboot_cfg}),
+  chk_file_exists($media->{grub_earlyboot_cfg}),
   "early grub config exists",
   "Early grub config must exist and have non-zero size.";
 
 show_conditional
   $media->{grub_earlyboot_cfg},
-  chk_grub_root_exists($iso_dir, $media->{grub_earlyboot_cfg}),
+  chk_grub_root_exists($media->{grub_earlyboot_cfg}),
   "grub early config references correct root file system",
   "$media->{grub_earlyboot_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
 
 show_conditional
   $media->{grub_cfg},
-  chk_file_exists($iso_ls_rockridge, $media->{grub_cfg}),
+  chk_file_exists($media->{grub_cfg}),
   "grub config exists",
   "grub.cfg must exist and have non-zero size.";
 
 show_conditional
   $media->{grub_cfg},
-  chk_grub_root_exists($iso_dir, $media->{grub_cfg}),
+  chk_grub_root_exists($media->{grub_cfg}),
   "grub config references correct root file system",
   "$media->{grub_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
 
 show_conditional
   $media->{efi_grub_cfg},
-  chk_file_exists($iso_ls_rockridge, $media->{efi_grub_cfg}),
+  chk_file_exists($media->{efi_grub_cfg}),
   "UEFI grub config exists",
   "UEFI grub.cfg must exist and have non-zero size.";
 
 show_conditional
   $media->{efi_grub_cfg},
-  chk_grub_root_exists($iso_dir, $media->{efi_grub_cfg}),
+  chk_grub_root_exists($media->{efi_grub_cfg}),
   "UEFI grub config references correct root file system",
   "$media->{efi_grub_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
 
 show_conditional
   $media->{efi_loader},
-  chk_file_exists($iso_ls_rockridge, $media->{efi_loader}),
+  chk_file_exists($media->{efi_loader}),
   "UEFI boot loader exists",
   "UEFI boot loader must exist and have non-zero size.";
 
 show_conditional
   $media->{efi_image},
-  chk_file_exists_optional($iso_ls_rockridge, $media->{efi_image}),
+  chk_file_exists_optional($media->{efi_image}),
   "UEFI boot image exists",
   "UEFI boot image should exist and have non-zero size.";
 
-if($media->{variant} eq 'live' && -f "$iso_dir/$media->{initrd}") {
-  $initrd_dir = unpack_initrd $iso_dir, $media->{initrd};
+if($media->{variant} eq 'live') {
+  $initrd_dir = unpack_initrd $media->{initrd};
 }
 
 if($media->{variant} eq 'live') {
-  $media->{root_option_initrd} = get_root_option_initrd $iso_dir, $initrd_dir;
+  $media->{root_option_initrd} = get_root_option_initrd $initrd_dir;
   print "- root option: $media->{root_option_initrd}\n" if $media->{root_option_initrd} && $opt_verbose >= 1;
 
   show
@@ -423,7 +407,7 @@ if($media->{variant} eq 'live') {
 }
 
 if($media->{variant} eq 'selfinstall') {
-  $media->{root_option_bootloader} = get_root_option_bootloader $iso_dir, $media;
+  $media->{root_option_bootloader} = get_root_option_bootloader $media;
   print "- root option: $media->{root_option_bootloader}\n" if $media->{root_option_bootloader} && $opt_verbose >= 1;
 
   show
@@ -454,10 +438,6 @@ General options:
       --version                   Show verifymedia version.
       --save-temp                 Keep temporary files.
       --help                      Write this help text.
-
-Debug options:
-      --mount-iso                 Mount ISO images to access them (default if run as root).
-      --no-mount-iso              Unpack ISO images to access them (default if run as normal user).
 
 More information is available in the verifymedia(1) manual page.
 = = = = = = = =
@@ -586,10 +566,11 @@ sub chk_files_owner
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub chk_file_exists
 {
-  my $iso_by_name = $_[0]->{by_name};
-  my $file = $_[1];
+  my $file = $_[0];
 
-  my $ok = $iso_by_name->{$file} && $iso_by_name->{$file}{size} > 0 ? 1 : 0;
+  my $stat = stat_file $file;
+
+  my $ok = $stat && $stat->{size} > 0 ? 1 : 0;
 
   $error_detail = $file if !$ok;
 
@@ -611,15 +592,14 @@ sub chk_file_exists_optional
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub chk_grub_root_exists
 {
-  my $dir = $_[0];
-  my $grub_cfg = $_[1];
+  my $grub_cfg = $_[0];
 
-  my $grub_root = get_grub_root $iso_dir, $grub_cfg;
+  my $grub_root = get_grub_root $grub_cfg;
 
   my $state;
 
   if($grub_root ne "") {
-    $state = -f "$iso_dir/$grub_root" ? 1 : 0;
+    $state = is_file($grub_root) ? 1 : 0;
   }
 
   $error_detail = $grub_root if !$state;
@@ -646,8 +626,7 @@ sub chk_treeinfo_arch
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub chk_treeinfo_files
 {
-  my $iso_by_name = $_[0]->{by_name};
-  my $media = $_[1];
+  my $media = $_[0];
 
   return 0 unless $media->{treeinfo};
 
@@ -656,9 +635,7 @@ sub chk_treeinfo_files
   for my $section (sort keys %{$media->{treeinfo}}) {
     my $t = $media->{treeinfo}{$section};
     for my $file ('initrd', 'kernel') {
-      if($t->{$file} && !$iso_by_name->{$t->{$file}}) {
-        $missing->{$t->{$file}} = 1;
-      }
+      $missing->{$t->{$file}} = 1 if $t->{$file} && !is_file $t->{$file};
     }
   }
 
@@ -675,13 +652,14 @@ sub chk_treeinfo_files
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub chk_bootinfo
 {
-  my $iso_dir = $_[0];
-  my $iso_by_name = $_[1]->{by_name};
-  my $media = $_[2];
+  my $media = $_[0];
+
+  # use $iso_ls_plain as PowerPC firmware does not understand Rock Ridge extension
+  my $iso_by_name = $iso_ls_plain->{by_name};
 
   return 0 unless $media->{bootinfo_txt} && $iso_by_name->{$media->{bootinfo_txt}};
 
-  my $data = read_file $iso_dir, $media->{bootinfo_txt};
+  my $data = read_file $media->{bootinfo_txt};
 
   my $grub;
 
@@ -734,31 +712,6 @@ sub get_iso9660_info
   print "- iso header info:\n", Dumper($iso9660) if $opt_verbose >= 2;
 
   return $data;
-}
-
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub unpack_iso_image
-{
-  my $iso = $_[0];
-
-  my $dir;
-
-  $opt_mount_iso = check_root if ! defined $opt_mount_iso;
-  if($opt_mount_iso) {
-    check_root "Sorry, can't access ISO images; you need root privileges.";
-    print "- mounting $iso\n" if $opt_verbose >= 1;
-    $dir = $tmp->mnt("iso");
-    susystem "mount -oro,loop $iso $dir";
-  }
-  else {
-    print "- unpacking $iso\n" if $opt_verbose >= 1;
-    $dir = $tmp->dir();
-    system "cd $dir && isoinfo -i '" . abs_path($iso) . "' -RJX 2>/dev/null && chmod -R a=r,a=rX,u+w ."
-      and die "$iso: ISO unpacking failed\n";
-  }
-
-  return $dir;
 }
 
 
@@ -827,53 +780,6 @@ sub iso_ls
 }
 
 
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# check_root(msg)
-#
-# Checks if we can get root privileges if required.
-#
-# - msg: message to show to user if things fail
-#        if msg is not set, return status whether running as root is possible
-#
-sub check_root
-{
-  my $p;
-  my $msg = shift;
-
-  if(!$config->{sudo_checked}) {
-    $config->{sudo_checked} = 1;
-
-    $config->{check_root_ok} = 0;
-    if(!$>) {
-      delete $config->{sudo};
-      $config->{check_root_ok} = 1;
-    }
-    else {
-      my $p;
-      chomp($p = `bash -c 'type -p $config->{sudo}'`) if $config->{sudo};
-      $config->{check_root_ok} = 1 if $p ne "";
-    }
-  }
-
-  die "$msg\n" if !$config->{check_root_ok} && $msg;
-
-  return $config->{check_root_ok};
-}
-
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# susystem(cmd)
-#
-# Run command with root privileges.
-#
-# - cmd: command to run
-#
-sub susystem
-{
-  system "$config->{sudo} $_[0]";
-}
-
-
 # -------------------------------------------------------------------------------------------------
 # -------------------------------------------------------------------------------------------------
 # -------------------------------------------------------------------------------------------------
@@ -894,14 +800,12 @@ sub susystem
 #
 sub get_media_style
 {
-  my $dir = $_[0];
-
-  if(-d "$dir/isolinux" || -f "$dir/.discinfo") {
+  if(is_dir "isolinux" || is_file ".discinfo" || is_dir 'Packages') {
     return 'rh';
   }
 
-  for my $file (glob "$dir/*/Packages") {
-    return 'rh' if -d $file;
+  for my $stream ('BaseOS', 'AppStream') {
+    return 'rh' if is_dir "$stream/Packages";
   }
 
   return 'suse';
@@ -919,10 +823,8 @@ sub get_media_style
 #
 sub get_media_variant
 {
-  my $dir = $_[0];
-
-  return 'live' if -d "$dir/LiveOS";
-  return 'selfinstall' if -f "$dir/config.isoclient";
+  return 'live' if is_dir "LiveOS";
+  return 'selfinstall' if is_file "config.isoclient";
 
   return 'install';
 }
@@ -931,9 +833,11 @@ sub get_media_variant
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub read_treeinfo
 {
-  my $dir = $_[0];
+  my $ini;
 
-  my $ini = read_ini "$dir/.treeinfo";
+  if(extract_file ".treeinfo") {
+    $ini = read_ini ".treeinfo";
+  }
 
   return $ini;
 }
@@ -954,7 +858,7 @@ sub read_ini
   my $ini;
   my $section;
 
-  if(open my $f, $file) {
+  if(open my $f, "$iso_dir/$file") {
     while(<$f>) {
       chomp;
       s/\s*;.*//;
@@ -978,29 +882,20 @@ sub read_ini
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_arch
 {
-  my $iso_by_name = $_[0]->{by_name};
-  my $treeinfo = $_[1];
-
   my $arch;
 
-  # Note: .treeinfo is broken on SUSE media
-  #
-  # if($treeinfo) {
-  #   return $treeinfo->{general}{arch} if $treeinfo->{general} && $treeinfo->{general}{arch};
-  # }
-
   for my $x ('aarch64', 'i386', 'ppc64', 'ppc64le', 's390x', 'x86_64') {
-    return $x if $iso_by_name->{"boot/$x"};
+    return $x if is_dir "boot/$x";
   }
 
-  return 'x86_64' if $iso_by_name->{"EFI/BOOT/BOOTX64.EFI"};
-  return 'x86_64' if $iso_by_name->{"EFI/BOOT/bootx64.efi"};
+  return 'x86_64' if is_file "EFI/BOOT/BOOTX64.EFI";
+  return 'x86_64' if is_file "EFI/BOOT/bootx64.efi";
 
-  return 'i386' if $iso_by_name->{"EFI/BOOT/BOOTIA32.EFI"};
-  return 'i386' if $iso_by_name->{"EFI/BOOT/bootia32.efi"};
+  return 'i386' if is_file "EFI/BOOT/BOOTIA32.EFI";
+  return 'i386' if is_file "EFI/BOOT/bootia32.efi";
 
-  return 'aarch64' if $iso_by_name->{"EFI/BOOT/BOOTAA64.EFI"};
-  return 'aarch64' if $iso_by_name->{"EFI/BOOT/bootaa64.efi"};
+  return 'aarch64' if is_file "EFI/BOOT/BOOTAA64.EFI";
+  return 'aarch64' if is_file "EFI/BOOT/bootaa64.efi";
 
   return $arch;
 }
@@ -1009,8 +904,7 @@ sub get_arch
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_expected_media_layout
 {
-  my $dir = $_[0];
-  my $media = $_[1];
+  my $media = $_[0];
 
   my $arch = $media->{arch};
 
@@ -1067,14 +961,8 @@ sub get_expected_media_layout
       $media->{efi_image} = "boot/aarch64/loader/efiboot.img";
       $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
-      if(open my $fd, "$dir/boot/mbrid") {
-        my $id = <$fd>;
-        close $fd;
-        chomp $id;
-        if($id && -f "$dir/boot/$id") {
-          $media->{grub_search_id} = "/boot/$id";
-        }
-      }
+      chomp(my $id = read_file "boot/mbrid");
+      $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/initrd";
@@ -1100,14 +988,8 @@ sub get_expected_media_layout
       $media->{efi_image} = "boot/x86_64/loader/efiboot.img";
       $media->{efi_loader} = "EFI/BOOT/bootx64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
-      if(open my $fd, "$dir/boot/mbrid") {
-        my $id = <$fd>;
-        close $fd;
-        chomp $id;
-        if($id && -f "$dir/boot/$id") {
-          $media->{grub_search_id} = "/boot/$id";
-        }
-      }
+      chomp(my $id = read_file "boot/mbrid");
+      $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
     }
   }
   elsif($media->{variant} eq 'selfinstall') {
@@ -1118,14 +1000,8 @@ sub get_expected_media_layout
       $media->{efi_image} = "boot/aarch64/loader/efiboot.img";
       $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
-      if(open my $fd, "$dir/boot/mbrid") {
-        my $id = <$fd>;
-        close $fd;
-        chomp $id;
-        if($id && -f "$dir/boot/$id") {
-          $media->{grub_search_id} = "/boot/$id";
-        }
-      }
+      chomp(my $id = read_file "boot/mbrid");
+      $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/loader/initrd";
@@ -1151,30 +1027,71 @@ sub get_expected_media_layout
       $media->{efi_image} = "boot/x86_64/loader/efiboot.img";
       $media->{efi_loader} = "EFI/BOOT/bootx64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
-      if(open my $fd, "$dir/boot/mbrid") {
-        my $id = <$fd>;
-        close $fd;
-        chomp $id;
-        if($id && -f "$dir/boot/$id") {
-          $media->{grub_search_id} = "/boot/$id";
-        }
-      }
+      chomp(my $id = read_file "boot/mbrid");
+      $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
     }
   }
 }
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Note: uses global var $iso_ls_rockridge.
+#
+sub stat_file
+{
+  my $file = $_[0];
+
+  return undef if !defined $file;
+
+  my $stat = $iso_ls_rockridge->{by_name}{$file};
+
+  return $stat;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub is_dir
+{
+  my $file = $_[0];
+
+  my $stat = stat_file $file;
+
+  return $stat && $stat->{type} eq 'd';
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub is_file
+{
+  my $file = $_[0];
+
+  my $stat = stat_file $file;
+
+  return $stat && $stat->{type} eq ' ';
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Note: uses global var $src.
+#
 sub read_file
 {
-  my $dir = $_[0];
-  my $file = $_[1];
+  my $file = $_[0];
+
+  my $stat = stat_file $file;
+
+  return undef if !defined($stat) || $stat->{type} ne " ";
 
   my $data;
 
-  if(open my $fd, "$dir/$file") {
-    local $/;
-    $data = <$fd>;
+  if(open my $fd, $src) {
+    sysseek($fd, $stat->{start} * 2048, 0) or die "$src: seek to block $stat->{start} failed\n";
+    if($stat->{size}) {
+      sysread($fd, $data, $stat->{size}) == $stat->{size} or die "$src: reading $stat->{size} bytes failed\n";
+    }
+    else {
+      $data = "";
+    }
     close $fd;
   }
 
@@ -1183,12 +1100,49 @@ sub read_file
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Note: uses global var $iso_dir.
+#
+sub extract_file
+{
+  my $file = $_[0];
+
+  my $stat = stat_file $file;
+
+  return undef if !defined($stat) || $stat->{type} ne " ";
+
+  return 1 if $stat->{extracted};
+
+  my $dir = $file;
+  $dir =~ s#[^/]+$##;
+
+  make_path "$iso_dir/$dir" if $dir ne "";
+
+  my $ok;
+
+  if(-d "$iso_dir/$dir") {
+    my $data = read_file $file;
+    if(defined $data) {
+      if(open my $fd, ">", "$iso_dir/$file") {
+        $ok = syswrite($fd, $data) == length($data);
+        close $fd;
+      }
+    }
+  }
+
+  $stat->{extracted} = 1 if $ok;
+
+  die "$file: extracting failed\n" unless $ok;
+
+  return 1;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_grub_root
 {
-  my $dir = $_[0];
-  my $file = $_[1];
+  my $file = $_[0];
 
-  my $data = read_file $dir, $file;
+  my $data = read_file $file;
 
   my $root;
 
@@ -1554,20 +1508,21 @@ sub file_magic
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub unpack_initrd
 {
-  my $dir = $_[0];
-  my $file = $_[1];
+  my $file = $_[0];
 
-  return undef unless $file;
+  return undef unless is_file($file);
+
+  extract_file $file;
 
   my $tmp_dir = $tmp->dir('initrd');
 
-  my $type = get_archive_type "$dir/$file";
+  my $type = get_archive_type "$iso_dir/$file";
 
   if($type) {
-    unpack_archive $type, "$dir/$file", $tmp_dir;
+    unpack_archive $type, "$iso_dir/$file", $tmp_dir;
   }
   else {
-    die "$dir: initrd unpacking failed\n";
+    die "$iso_dir: initrd unpacking failed\n";
   }
 
   return $tmp_dir;
@@ -1577,8 +1532,7 @@ sub unpack_initrd
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_root_option_initrd
 {
-  my $iso = $_[0];
-  my $initrd = $_[1];
+  my $initrd = $_[0];
 
   return undef unless $initrd;
 
@@ -1595,12 +1549,9 @@ sub get_root_option_initrd
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_root_option_bootloader
 {
-  my $iso = $_[0];
-  my $media = $_[1];
+  my $media = $_[0];
 
-  return undef unless $media->{grub_cfg};
-
-  my $grub_cfg = `cat $iso/$media->{grub_cfg}`;
+  my $grub_cfg = read_file $media->{grub_cfg};
 
   return $1 if $grub_cfg =~ /^\s*linux .* root=(\S+)/m;
 

--- a/verifymedia
+++ b/verifymedia
@@ -230,6 +230,7 @@ die "$src: not readable\n" unless -r _;
 
 ($src_short = $src) =~ s#^.*/##;
 print "Verifying: $src_short\n";
+print "Check results: [✔] = ok, [✘] = bad, [!] = not ideal\n";
 
 $iso_dir = $tmp->dir('iso');
 

--- a/verifymedia
+++ b/verifymedia
@@ -151,6 +151,9 @@ sub chk_files_owner;
 sub chk_file_exists;
 sub chk_file_exists_optional;
 sub chk_grub_root_exists;
+sub chk_treeinfo_arch;
+sub chk_treeinfo_files;
+sub chk_bootinfo;
 
 sub check_root;
 sub susystem;
@@ -170,7 +173,8 @@ sub unpack_cpiox;
 sub unpack_archive;
 sub file_magic;
 sub unpack_initrd;
-sub get_live_root;
+sub get_root_option_initrd;
+sub get_root_option_bootloader;
 
 my $opt_save_temp;
 my $opt_verbose = 0;
@@ -185,7 +189,7 @@ my $error_detail;
 my $src;
 my $src_short;
 my $iso_ls_rockridge;
-my $treeinfo;
+my $iso_ls_plain;
 my $iso_dir;
 my $initrd_dir;
 
@@ -245,6 +249,7 @@ show
   "image uses Joliet extension",
   "ISO image must use Joliet extension ('mkisofs -J', 'xorriso -joliet on').";
 
+$iso_ls_plain = iso_ls $src;
 $iso_ls_rockridge = iso_ls $src, "rockridge";
 print "- iso file list (rock ridge):\n", Dumper($iso_ls_rockridge) if $opt_verbose >= 2;
 
@@ -260,75 +265,116 @@ show
   "all files are owned by root",
   "Files on the ISO image should have uid and gid 0.";
 
-$treeinfo = read_treeinfo $iso_dir;
-print "- .treeinfo:\n", Dumper($treeinfo) if $opt_verbose >= 2;
+$media->{treeinfo} = read_treeinfo $iso_dir;
+print "- .treeinfo:\n", Dumper($media->{treeinfo}) if $media->{treeinfo} && $opt_verbose >= 2;
 
 $media->{style} = get_media_style $iso_dir;
 $media->{variant} = get_media_variant $iso_dir;
-$media->{arch} = get_arch $iso_dir, $treeinfo;
+$media->{arch} = get_arch $iso_ls_rockridge, $media->{treeinfo};
 get_expected_media_layout $iso_dir, $media;
 
 print "- media:\n", Dumper($media) if $opt_verbose >= 2;
 die "failed to detect architecture\n" unless $media->{arch};
-print "- media style: $media->{style}\n" if $opt_verbose >= 1;
-print "- media variant: $media->{variant}\n" if $opt_verbose >= 1;
-print "- media architecture: $media->{arch}\n" if $opt_verbose >= 1;
 
 show
-  chk_file_exists($iso_dir, $media->{kernel}),
+  $media->{style} ne "",
+  "media style: $media->{style}",
+  "Could not determine media style.";
+
+show
+  $media->{variant} ne "",
+  "media variant: $media->{variant}",
+  "Could not determine media variant.";
+
+show
+  $media->{arch} ne "",
+  "media architecture: $media->{arch}",
+  "Could not determine media architecture.";
+
+show_and_exit
+  $media->{kernel} ne "",
+  "media layout supported",
+  "This media layout is not supported by verifymedia.";
+
+show_conditional
+  $media->{treeinfo},
+  chk_treeinfo_arch($media),
+  ".treeinfo architecture matches",
+  "arch entry in general section in .treeinfo must match media architecture.";
+
+show_conditional
+  $media->{treeinfo},
+  chk_treeinfo_files($iso_ls_rockridge, $media),
+  "kernel and initrd referenced in .treeinfo exist",
+  "Kernel and initrd referenced in .treeinfo must exist.";
+
+show
+  chk_file_exists($iso_ls_rockridge, $media->{kernel}),
   "kernel exists",
   "Kernel must exist and have non-zero size.";
 
 show
-  chk_file_exists($iso_dir, $media->{initrd}),
+  chk_file_exists($iso_ls_rockridge, $media->{initrd}),
   "initrd exists",
   "Initrd must exist and have non-zero size.";
 
 show_conditional
   $media->{initrd_off},
-  chk_file_exists($iso_dir, $media->{initrd_off}),
+  chk_file_exists($iso_ls_rockridge, $media->{initrd_off}),
   "initrd.off exists",
   "initrd.off must exist and have non-zero size.";
 
 show_conditional
   $media->{initrd_siz},
-  chk_file_exists($iso_dir, $media->{initrd_siz}),
+  chk_file_exists($iso_ls_rockridge, $media->{initrd_siz}),
   "initrd.siz exists",
   "initrd.siz must exist and have non-zero size.";
 
 show_conditional
   $media->{cd_ikr},
-  chk_file_exists($iso_dir, $media->{cd_ikr}),
+  chk_file_exists($iso_ls_rockridge, $media->{cd_ikr}),
   "cd.ikr exists",
   "cd.ikr must exist and have non-zero size.";
 
 show_conditional
   $media->{suse_ins},
-  chk_file_exists($iso_dir, $media->{suse_ins}),
+  chk_file_exists($iso_ls_rockridge, $media->{suse_ins}),
   "suse.ins exists",
   "suse.ins must exist and have non-zero size.";
 
 show_conditional
   $media->{isolinux_cfg},
-  chk_file_exists($iso_dir, $media->{isolinux_cfg}),
+  chk_file_exists($iso_ls_rockridge, $media->{isolinux_cfg}),
   "isolinux config exists",
   "isolinux.cfg must exist and have non-zero size.";
 
 show_conditional
+  $media->{bootinfo_txt},
+  chk_file_exists($iso_ls_rockridge, $media->{bootinfo_txt}),
+  "bootinfo config exists",
+  "bootinfo.txt must exist and have non-zero size.";
+
+show_conditional
+  $media->{bootinfo_txt},
+  chk_bootinfo($iso_dir, $iso_ls_plain, $media),	# use $iso_ls_plain as PowerPC firmware does not understand Rock Ridge extension
+  "bootinfo config points to grub",
+  "boot-script entry in bootinfo.txt must point to grub and\ngrub must have a config file in the same location.";
+
+show_conditional
   $media->{grub_earlyboot_cfg},
-  chk_file_exists($iso_dir, $media->{grub_earlyboot_cfg}),
-  "grub earlyboot config exists",
-  "earlyboot.cfg must exist and have non-zero size.";
+  chk_file_exists($iso_ls_rockridge, $media->{grub_earlyboot_cfg}),
+  "early grub config exists",
+  "Early grub config must exist and have non-zero size.";
 
 show_conditional
   $media->{grub_earlyboot_cfg},
   chk_grub_root_exists($iso_dir, $media->{grub_earlyboot_cfg}),
-  "grub earlyboot config references correct root file system",
+  "grub early config references correct root file system",
   "$media->{grub_earlyboot_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
 
 show_conditional
   $media->{grub_cfg},
-  chk_file_exists($iso_dir, $media->{grub_cfg}),
+  chk_file_exists($iso_ls_rockridge, $media->{grub_cfg}),
   "grub config exists",
   "grub.cfg must exist and have non-zero size.";
 
@@ -340,7 +386,7 @@ show_conditional
 
 show_conditional
   $media->{efi_grub_cfg},
-  chk_file_exists($iso_dir, $media->{efi_grub_cfg}),
+  chk_file_exists($iso_ls_rockridge, $media->{efi_grub_cfg}),
   "UEFI grub config exists",
   "UEFI grub.cfg must exist and have non-zero size.";
 
@@ -352,13 +398,13 @@ show_conditional
 
 show_conditional
   $media->{efi_loader},
-  chk_file_exists($iso_dir, $media->{efi_loader}),
+  chk_file_exists($iso_ls_rockridge, $media->{efi_loader}),
   "UEFI boot loader exists",
   "UEFI boot loader must exist and have non-zero size.";
 
 show_conditional
   $media->{efi_image},
-  chk_file_exists_optional($iso_dir, $media->{efi_image}),
+  chk_file_exists_optional($iso_ls_rockridge, $media->{efi_image}),
   "UEFI boot image exists",
   "UEFI boot image should exist and have non-zero size.";
 
@@ -367,13 +413,23 @@ if($media->{variant} eq 'live' && -f "$iso_dir/$media->{initrd}") {
 }
 
 if($media->{variant} eq 'live') {
-  $media->{live_root} = get_live_root $iso_dir, $initrd_dir;
-  print "- live root fs: $media->{live_root}\n" if $media->{live_root} && $opt_verbose >= 1;
+  $media->{root_option_initrd} = get_root_option_initrd $iso_dir, $initrd_dir;
+  print "- root option: $media->{root_option_initrd}\n" if $media->{root_option_initrd} && $opt_verbose >= 1;
 
   show
-    $media->{live_root} && $media->{live_root} eq "LABEL=$iso9660->{volume_id}",
+    $media->{root_option_initrd} && $media->{root_option_initrd} eq "live:LABEL=$iso9660->{volume_id}",
     "ISO label matches dracut live root option",
-    "ISO label '$iso9660->{volume_id}' must correspond to dracut live root option '$media->{live_root}'.";
+    "ISO label '$iso9660->{volume_id}' must correspond to dracut live root option '$media->{root_option_initrd}'.";
+}
+
+if($media->{variant} eq 'selfinstall') {
+  $media->{root_option_bootloader} = get_root_option_bootloader $iso_dir, $media;
+  print "- root option: $media->{root_option_bootloader}\n" if $media->{root_option_bootloader} && $opt_verbose >= 1;
+
+  show
+    $media->{root_option_bootloader} && $media->{root_option_bootloader} eq "install:CDLABEL=$iso9660->{volume_id}",
+    "ISO label matches kiwi install root option",
+    "ISO label '$iso9660->{volume_id}' must correspond to kiwi install root option '$media->{root_option_bootloader}'.";
 }
 
 print "- $errors error(s)\n" if $opt_verbose >= 1;
@@ -456,9 +512,11 @@ sub show
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub show_and_exit
 {
+  my $errors_old = $errors;
+
   show @_;
 
-  exit 1 if $errors;
+  exit 1 if $errors > $errors_old;
 }
 
 
@@ -494,10 +552,10 @@ sub chk_rockridge
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub chk_files_permission
 {
-  my $files = $_[0];
+  my $iso_list = $_[0]->{list};
   my $ok = 1;
 
-  for my $file (@$files) {
+  for my $file (@$iso_list) {
     if(substr($file->{perm}, 6, 1) ne 'r') {
       $error_detail .= sprintf "%s %3d %3d %10d %s\n", $file->{perm}, $file->{uid}, $file->{gid}, $file->{size}, $file->{name};
       $ok = 0;
@@ -511,10 +569,10 @@ sub chk_files_permission
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub chk_files_owner
 {
-  my $files = $_[0];
+  my $iso_list = $_[0]->{list};
   my $ok = 1;
 
-  for my $file (@$files) {
+  for my $file (@$iso_list) {
     if($file->{uid} != 0 || $file->{gid} != 0) {
       $error_detail .= sprintf "%s %3d %3d %10d %s\n", $file->{perm}, $file->{uid}, $file->{gid}, $file->{size}, $file->{name};
       $ok = 0;
@@ -528,10 +586,10 @@ sub chk_files_owner
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub chk_file_exists
 {
-  my $dir = $_[0];
+  my $iso_by_name = $_[0]->{by_name};
   my $file = $_[1];
 
-  my $ok = $file ne "" && -s "$dir/$file" ? 1 : 0;
+  my $ok = $iso_by_name->{$file} && $iso_by_name->{$file}{size} > 0 ? 1 : 0;
 
   $error_detail = $file if !$ok;
 
@@ -567,6 +625,91 @@ sub chk_grub_root_exists
   $error_detail = $grub_root if !$state;
 
   return $state;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_treeinfo_arch
+{
+  my $media = $_[0];
+
+  return 0 unless $media->{treeinfo} && $media->{treeinfo}{general};
+
+  return 1 if $media->{arch} eq $media->{treeinfo}{general}{arch};
+
+  $error_detail = "'$media->{treeinfo}{general}{arch}' != '$media->{arch}'";
+
+  return 0;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_treeinfo_files
+{
+  my $iso_by_name = $_[0]->{by_name};
+  my $media = $_[1];
+
+  return 0 unless $media->{treeinfo};
+
+  my $missing;
+
+  for my $section (sort keys %{$media->{treeinfo}}) {
+    my $t = $media->{treeinfo}{$section};
+    for my $file ('initrd', 'kernel') {
+      if($t->{$file} && !$iso_by_name->{$t->{$file}}) {
+        $missing->{$t->{$file}} = 1;
+      }
+    }
+  }
+
+  return 1 if !$missing;
+
+  for my $m (sort keys %$missing) {
+    $error_detail .= "$m\n";
+  }
+
+  return 0;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_bootinfo
+{
+  my $iso_dir = $_[0];
+  my $iso_by_name = $_[1]->{by_name};
+  my $media = $_[2];
+
+  return 0 unless $media->{bootinfo_txt} && $iso_by_name->{$media->{bootinfo_txt}};
+
+  my $data = read_file $iso_dir, $media->{bootinfo_txt};
+
+  my $grub;
+
+  if($data =~ /,([^,]+)<\/boot-script>/) {
+    $grub = $1;
+    $grub =~ tr#\\#/#;
+    $grub =~ s#^/##;
+  }
+
+  if($grub eq "") {
+    $error_detail = "$media->{bootinfo_txt}: no <boot-script> element found";
+    return 0;
+  }
+
+  if(!$iso_by_name->{$grub}) {
+    $error_detail = "$media->{bootinfo_txt}: boot-script $grub does not exists";
+    return 0;
+  }
+
+  my $cfg = $grub;
+  $cfg =~ s#[^/]*$#grub.cfg#;
+
+  if($cfg ne $media->{grub_cfg} && $cfg ne $media->{grub_earlyboot_cfg} ) {
+    $error_detail = "expecting grub config $cfg for $grub";
+    return 0;
+  }
+
+  return 1;
 }
 
 
@@ -622,7 +765,7 @@ sub unpack_iso_image
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # ISO file list sorted by start address.
 #
-# Return ref to array with files.
+# Return ref to hash with files.
 #
 sub iso_ls
 {
@@ -670,9 +813,17 @@ sub iso_ls
 
   close $fd;
 
-  $files = [ sort { $a->{start} <=> $b->{start} } @$files ] if $files;
+  my $by_name;
 
-  return $files;
+  if($files) {
+    $files = [ sort { $a->{start} <=> $b->{start} } @$files ];
+
+    for my $n (@$files) {
+      $by_name->{$n->{name}} = $n;
+    }
+  }
+
+  return { list => $files, by_name => $by_name };
 }
 
 
@@ -827,7 +978,7 @@ sub read_ini
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_arch
 {
-  my $dir = $_[0];
+  my $iso_by_name = $_[0]->{by_name};
   my $treeinfo = $_[1];
 
   my $arch;
@@ -839,8 +990,17 @@ sub get_arch
   # }
 
   for my $x ('aarch64', 'i386', 'ppc64', 'ppc64le', 's390x', 'x86_64') {
-    return $x if -d "$dir/boot/$x";
+    return $x if $iso_by_name->{"boot/$x"};
   }
+
+  return 'x86_64' if $iso_by_name->{"EFI/BOOT/BOOTX64.EFI"};
+  return 'x86_64' if $iso_by_name->{"EFI/BOOT/bootx64.efi"};
+
+  return 'i386' if $iso_by_name->{"EFI/BOOT/BOOTIA32.EFI"};
+  return 'i386' if $iso_by_name->{"EFI/BOOT/bootia32.efi"};
+
+  return 'aarch64' if $iso_by_name->{"EFI/BOOT/BOOTAA64.EFI"};
+  return 'aarch64' if $iso_by_name->{"EFI/BOOT/bootaa64.efi"};
 
   return $arch;
 }
@@ -856,6 +1016,8 @@ sub get_expected_media_layout
 
   return unless $arch;
 
+  return unless $media->{style} eq 'suse';
+
   if($media->{variant} eq 'install') {
     if($arch eq 'aarch64') {
       $media->{initrd} = "boot/aarch64/initrd";
@@ -863,9 +1025,21 @@ sub get_expected_media_layout
       $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
     }
+    elsif($arch eq 'i386') {
+      $media->{isolinux_cfg} = "boot/i386/loader/isolinux.cfg";
+      $media->{el_torito_image} = "boot/i386/loader/isolinux.bin";
+      $media->{initrd} = "boot/i386/loader/initrd";
+      $media->{kernel} = "boot/i386/loader/linux";
+      $media->{efi_image} = "boot/i386/efi";
+      $media->{efi_loader} = "EFI/BOOT/bootia32.efi";
+      $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+    }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/initrd";
       $media->{kernel} = "boot/ppc64le/linux";
+      $media->{bootinfo_txt} = "ppc/bootinfo.txt";
+      $media->{grub_cfg} = "boot/grub2/grub.cfg";
+      $media->{grub_earlyboot_cfg} = "boot/ppc64le/grub2-ieee1275/grub.cfg";
     }
     elsif($arch eq 's390x') {
       $media->{initrd} = "boot/s390x/initrd";
@@ -905,6 +1079,9 @@ sub get_expected_media_layout
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/initrd";
       $media->{kernel} = "boot/ppc64le/linux";
+      $media->{bootinfo_txt} = "ppc/bootinfo.txt";
+      $media->{grub_cfg} = "boot/grub2/grub.cfg";
+      $media->{grub_earlyboot_cfg} = "boot/grub2/powerpc-ieee1275/grub.cfg";
     }
     elsif($arch eq 's390x') {
       $media->{initrd} = "boot/s390x/initrd";
@@ -951,8 +1128,11 @@ sub get_expected_media_layout
       }
     }
     elsif($arch eq 'ppc64le') {
-      $media->{initrd} = "boot/ppc64le/initrd";
-      $media->{kernel} = "boot/ppc64le/linux";
+      $media->{initrd} = "boot/ppc64le/loader/initrd";
+      $media->{kernel} = "boot/ppc64le/loader/linux";
+      $media->{bootinfo_txt} = "ppc/bootinfo.txt";
+      $media->{grub_cfg} = "boot/grub2/grub.cfg";
+      $media->{grub_earlyboot_cfg} = "boot/grub2/powerpc-ieee1275/grub.cfg";
     }
     elsif($arch eq 's390x') {
       $media->{initrd} = "boot/s390x/initrd";
@@ -1395,7 +1575,7 @@ sub unpack_initrd
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub get_live_root
+sub get_root_option_initrd
 {
   my $iso = $_[0];
   my $initrd = $_[1];
@@ -1406,7 +1586,23 @@ sub get_live_root
 
   my $config = `cat $initrd/etc/cmdline.d/*.conf`;
 
-  return $1 if $config =~ /^root=live:(\S+)/m;
+  return $1 if $config =~ /^root=(\S+)/m;
+
+  return undef;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub get_root_option_bootloader
+{
+  my $iso = $_[0];
+  my $media = $_[1];
+
+  return undef unless $media->{grub_cfg};
+
+  my $grub_cfg = `cat $iso/$media->{grub_cfg}`;
+
+  return $1 if $grub_cfg =~ /^\s*linux .* root=(\S+)/m;
 
   return undef;
 }

--- a/verifymedia
+++ b/verifymedia
@@ -152,6 +152,7 @@ sub chk_file_exists_optional;
 sub chk_treeinfo_arch;
 sub chk_treeinfo_files;
 sub chk_bootinfo;
+sub chk_garbage;
 
 sub susystem;
 sub get_iso9660_info;
@@ -233,6 +234,11 @@ show
   chk_joliet($iso9660),
   "image uses Joliet extension",
   "ISO image must use Joliet extension ('mkisofs -J', 'xorriso -joliet on').";
+
+show
+  $iso9660->{volume_id} ne "",
+  "image has volume id",
+  "ISO image must have a non-empty volume id.";
 
 $iso_ls_plain = iso_ls $src;
 $iso_ls_rockridge = iso_ls $src, "rockridge";
@@ -417,6 +423,11 @@ show_conditional
   $media->{root_option} =~ /^install:(?:CD)?LABEL=(.*)/ && $1 eq $iso9660->{volume_id},
   "ISO label matches kiwi install root option",
   "ISO label '$iso9660->{volume_id}' must correspond to kiwi install root option '$media->{root_option}'.";
+
+show
+  chk_garbage($media),
+  "no garbage files",
+  "These files are not needed and should be removed.";
 
 print "- $errors error(s)\n" if $opt_verbose >= 1;
 
@@ -672,6 +683,21 @@ sub chk_bootinfo
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_garbage
+{
+  my $media = $_[0];
+
+  undef $error_detail;
+
+  for my $f (sort keys %{$media->{garbage_files}}) {
+    $error_detail .= "$f\n" if stat_file $f;
+  }
+
+  return $error_detail ? 2 : 1;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_iso9660_info
 {
   my $iso = $_[0];
@@ -891,6 +917,11 @@ sub get_expected_media_layout
   return unless $arch;
 
   return unless $media->{style} eq 'suse';
+
+  # files that should not really be there
+  for my $f (qw ( glump ppc/os-chooser )) {
+    $media->{garbage_files}{$f} = 1;
+  }
 
   if($media->{variant} eq 'install') {
     if($arch eq 'aarch64') {

--- a/verifymedia
+++ b/verifymedia
@@ -149,7 +149,6 @@ sub chk_files_permission;
 sub chk_files_owner;
 sub chk_file_exists;
 sub chk_file_exists_optional;
-sub chk_grub_root_exists;
 sub chk_treeinfo_arch;
 sub chk_treeinfo_files;
 sub chk_bootinfo;
@@ -350,11 +349,13 @@ show_conditional
   "early grub config exists",
   "Early grub config must exist and have non-zero size.";
 
+$media->{grub_earlyboot_cfg_root} = get_grub_root $media->{grub_earlyboot_cfg};
+
 show_conditional
-  $media->{grub_earlyboot_cfg},
-  chk_grub_root_exists($media->{grub_earlyboot_cfg}),
+  $media->{grub_earlyboot_cfg_root},
+  chk_file_exists($media->{grub_earlyboot_cfg_root}),
   "grub early config references correct root file system",
-  "$media->{grub_earlyboot_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
+  "'$media->{grub_earlyboot_cfg}' searches for '$media->{grub_earlyboot_cfg_root}' to identify its root file system.\nThis file must exist.";
 
 show_conditional
   $media->{grub_cfg},
@@ -362,11 +363,13 @@ show_conditional
   "grub config exists",
   "grub.cfg must exist and have non-zero size.";
 
+$media->{grub_cfg_root} = get_grub_root $media->{grub_cfg};
+
 show_conditional
-  $media->{grub_cfg},
-  chk_grub_root_exists($media->{grub_cfg}),
+  $media->{grub_cfg_root},
+  chk_file_exists($media->{grub_cfg_root}),
   "grub config references correct root file system",
-  "$media->{grub_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
+  "'$media->{grub_cfg}' searches for '$media->{grub_cfg_root}' to identify its root file system.\nThis file must exist.";
 
 show_conditional
   $media->{efi_grub_cfg},
@@ -374,11 +377,13 @@ show_conditional
   "UEFI grub config exists",
   "UEFI grub.cfg must exist and have non-zero size.";
 
+$media->{efi_grub_cfg_root} = get_grub_root $media->{efi_grub_cfg};
+
 show_conditional
-  $media->{efi_grub_cfg},
-  chk_grub_root_exists($media->{efi_grub_cfg}),
+  $media->{efi_grub_cfg_root},
+  chk_file_exists($media->{efi_grub_cfg_root}),
   "UEFI grub config references correct root file system",
-  "$media->{efi_grub_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
+  "'$media->{efi_grub_cfg}' searches for '$media->{efi_grub_cfg_root}' to identify its root file system.\nThis file must exist.";
 
 show_conditional
   $media->{efi_loader},
@@ -392,29 +397,26 @@ show_conditional
   "UEFI boot image exists",
   "UEFI boot image should exist and have non-zero size.";
 
-if($media->{variant} eq 'live') {
+$media->{root_option} = get_root_option_bootloader $media;
+
+if(!$media->{root_option} && $media->{variant} eq 'live') {
   $initrd_dir = unpack_initrd $media->{initrd};
+  $media->{root_option} = get_root_option_initrd $initrd_dir;
 }
 
-if($media->{variant} eq 'live') {
-  $media->{root_option_initrd} = get_root_option_initrd $initrd_dir;
-  print "- root option: $media->{root_option_initrd}\n" if $media->{root_option_initrd} && $opt_verbose >= 1;
+print "- root option: $media->{root_option}\n" if $media->{root_option} && $opt_verbose >= 1;
 
-  show
-    $media->{root_option_initrd} && $media->{root_option_initrd} eq "live:LABEL=$iso9660->{volume_id}",
-    "ISO label matches dracut live root option",
-    "ISO label '$iso9660->{volume_id}' must correspond to dracut live root option '$media->{root_option_initrd}'.";
-}
+show_conditional
+  $media->{variant} eq 'live',
+  $media->{root_option} =~ /^live:(?:CD)?LABEL=(.*)/ && $1 eq $iso9660->{volume_id},
+  "ISO label matches dracut live root option",
+  "ISO label '$iso9660->{volume_id}' must correspond to dracut live root option '$media->{root_option}'.";
 
-if($media->{variant} eq 'selfinstall') {
-  $media->{root_option_bootloader} = get_root_option_bootloader $media;
-  print "- root option: $media->{root_option_bootloader}\n" if $media->{root_option_bootloader} && $opt_verbose >= 1;
-
-  show
-    $media->{root_option_bootloader} && $media->{root_option_bootloader} eq "install:CDLABEL=$iso9660->{volume_id}",
-    "ISO label matches kiwi install root option",
-    "ISO label '$iso9660->{volume_id}' must correspond to kiwi install root option '$media->{root_option_bootloader}'.";
-}
+show_conditional
+  $media->{variant} eq 'selfinstall',
+  $media->{root_option} =~ /^install:(?:CD)?LABEL=(.*)/ && $1 eq $iso9660->{volume_id},
+  "ISO label matches kiwi install root option",
+  "ISO label '$iso9660->{volume_id}' must correspond to kiwi install root option '$media->{root_option}'.";
 
 print "- $errors error(s)\n" if $opt_verbose >= 1;
 
@@ -453,24 +455,21 @@ sub show
   my $topic = $_[1];
   my $comment = $_[2];
 
-  if(defined $result) {
-    $result++;
-  }
-  else {
-    $result = 0;
-  }
+  $result += 0;
 
-  $errors++ if $result == 1;
+  $errors++ if $result == 0;
 
-  # values: not checked, bad, ok, not nice
-  my @mark = ( "", "\x{2718}", "\x{2714}", "!" );
+  # values: bad, ok, not nice
+  my @mark = ( "\x{2718}", "\x{2714}", "!" );
+
+  die "show(): oops, result $result out of range" if $result >= @mark;
 
   my $indent = "";
   my $indent_c = "  ";
   
   printf "${indent}[%-1s] %s\n", $mark[$result], $topic;
 
-  if($result == 1 || $result == 3) {
+  if($result == 0 || $result == 2) {
     $comment =~ s/\s+$//g;
     $comment =~ s/^\s*/$indent_c/;
     $comment =~ s/\n\s*/\n$indent_c/g;
@@ -586,25 +585,6 @@ sub chk_file_exists_optional
   $ok = 2 if !$ok;
 
   return $ok;
-}
-
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub chk_grub_root_exists
-{
-  my $grub_cfg = $_[0];
-
-  my $grub_root = get_grub_root $grub_cfg;
-
-  my $state;
-
-  if($grub_root ne "") {
-    $state = is_file($grub_root) ? 1 : 0;
-  }
-
-  $error_detail = $grub_root if !$state;
-
-  return $state;
 }
 
 
@@ -1553,7 +1533,7 @@ sub get_root_option_bootloader
 
   my $grub_cfg = read_file $media->{grub_cfg};
 
-  return $1 if $grub_cfg =~ /^\s*linux .* root=(\S+)/m;
+  return $1 if $grub_cfg =~ /^\s*\$?linux .* root=(\S+)/m;
 
   return undef;
 }

--- a/verifymedia
+++ b/verifymedia
@@ -132,6 +132,7 @@ use Data::Dumper;
 $Data::Dumper::Sortkeys = 1;
 $Data::Dumper::Terse = 1;
 $Data::Dumper::Indent = 1;
+$Data::Dumper::Deepcopy = 1;
 
 binmode(STDOUT, ":utf8");
 binmode(STDERR, ":utf8");
@@ -166,6 +167,8 @@ sub chk_treeinfo_files;
 sub chk_bootinfo;
 sub chk_garbage;
 sub chk_signature;
+sub chk_hybrid_chrp;
+sub chk_hybrid_efi;
 
 sub susystem;
 sub get_iso9660_info;
@@ -449,6 +452,66 @@ show
   "no garbage files",
   "These files are not needed and should be removed.";
 
+if($media->{hybrid_mode}) {
+  my $parti = `parti --json $src`;
+  $media->{parti} = decode_json($parti) if $parti;
+
+  print "- partition data:\n", Dumper($media->{parti}) if $media->{parti} && $opt_verbose >= 2;
+
+  my $hybrid;
+
+  $hybrid = chk_hybrid_chrp($media) if $media->{hybrid_mode} eq 'chrp';
+  $hybrid = chk_hybrid_efi($media) if $media->{hybrid_mode} eq 'efi';
+  $media->{hybrid} = $hybrid if $hybrid;
+
+  print "- hybrid data:\n", Dumper($media->{hybrid}) if $media->{hybrid} && $opt_verbose >= 2;
+
+  if($media->{hybrid_mode} eq 'efi') {
+    show
+      $hybrid && !$hybrid->{apple} && ($hybrid->{mbr} || $hybrid->{gpt}),
+      "has MBR or GPT partition table",
+      "To be bootable as disk image, there must be an MBR or GPT partition table.";
+
+    show
+      $hybrid && $hybrid->{efi_partition},
+      "has EFI System Partition with VFAT file system",
+      "To be UEFI bootable, there must be an EFI System Partition.";
+
+    show
+      $hybrid && $hybrid->{data_partition},
+      "has partition pointing to ISO image data",
+      "There must be a data partition pointing to the same file system you get\nwhen acessing the entire ISO image.";
+
+    show
+      $hybrid && !$hybrid->{invalid_partition},
+      "no invalid partition entries",
+      "Other partition table entries must have valid data or be completely empty.";
+  }
+
+  if($media->{hybrid_mode} eq 'chrp') {
+    show
+      $hybrid && $hybrid->{mbr} && !$hybrid->{gpt},
+      "has MBR partition table",
+      "To be bootable as disk image, there must be an MBR partition table.\nA GPT does not work.";
+
+    show
+      $hybrid && !$hybrid->{apple},
+      "has no Apple partition table",
+      "In the past we had (in addition to MBR) an Apple partition table; this is not\nneeded anymore (no PPC Macs) and leads to problems.";
+
+    show
+      $hybrid && $hybrid->{chrp_partition},
+      "has CHRP partition starting at block 0",
+      "To be bootable, the 1st partition must have type 0x96 and start at block 0.";
+
+    show
+      $hybrid && !$hybrid->{invalid_partition},
+      "no invalid partition entries",
+      "Other partition table entries must have valid data or be completely empty.";
+  }
+
+}
+
 my $sig = chk_signature $media;
 $media->{signature} = $sig if $sig;
 
@@ -488,11 +551,6 @@ show
   "ISO must be signed.";
 
 print "- $errors error(s)\n" if $opt_verbose >= 1;
-
-my $parti = `parti --json $src`;
-$media->{parti} = decode_json($parti) if $parti;
-
-print "- partition data:\n", Dumper($media->{parti}) if $media->{parti} && $opt_verbose >= 2;
 
 
 exit($errors ? 1 : 0);
@@ -795,6 +853,79 @@ sub chk_signature
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_hybrid_chrp
+{
+  my $media = $_[0];
+  my $hybrid;
+
+  my $parti = $media->{parti};
+
+  return unless $parti;
+
+  $hybrid->{apple} = 1 if $parti->{apple};
+  $hybrid->{gpt} = 1 if $parti->{gpt};
+
+  if($parti->{mbr}) {
+    $hybrid->{mbr} = 1;
+    for my $p (@{$parti->{mbr}{partitions}}) {
+      $hybrid->{invalid_partition} = 1, next if !$p->{attributes}{valid};
+      $hybrid->{chrp_partition} = 1 if $p->{index} == 0 && $p->{first_lba} == 0 && $p->{type_id} eq 0x96;
+    }
+  }
+
+  return $hybrid;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_hybrid_efi
+{
+  my $media = $_[0];
+  my $hybrid;
+
+  my $parti = $media->{parti};
+
+  return unless $parti;
+
+  my $uuid = $parti->{filesystem}{uuid} if $parti->{filesystem};
+  my $label = $parti->{filesystem}{label} if $parti->{filesystem};
+
+  $hybrid->{apple} = 1 if $parti->{apple};
+
+  my $partitions;
+
+  if($parti->{gpt_primary}) {
+    $hybrid->{gpt} = 1;
+    $partitions = $parti->{gpt_primary}{partitions};
+  }
+  elsif($parti->{mbr}) {
+    $hybrid->{mbr} = 1;
+    $partitions = $parti->{mbr}{partitions};
+  }
+
+  if($partitions) {
+    for my $p (@$partitions) {
+      $hybrid->{invalid_partition} = 1, next if $hybrid->{mbr} && !$p->{attributes}{valid};
+      $hybrid->{efi_partition} = 1 if
+        $p->{first_lba} != 0 &&
+        ($p->{type_name} eq "efi" || $p->{type_name} eq "efi system") &&
+        $p->{filesystem} &&
+        $p->{filesystem}{type} eq 'vfat';
+      $hybrid->{data_partition} = 1 if
+        $p->{first_lba} != 0 &&
+        $p->{filesystem} &&
+        $p->{filesystem}{type} eq 'iso9660' && (
+          ($p->{filesystem}{uuid} && $p->{filesystem}{uuid} eq $uuid) ||
+          ($p->{filesystem}{label} && $p->{filesystem}{label} eq $label)
+        );
+    }
+  }
+
+  return $hybrid;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_iso9660_info
 {
   my $iso = $_[0];
@@ -1011,6 +1142,7 @@ sub get_expected_media_layout
       $media->{kernel} = "boot/aarch64/linux";
       $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+      $media->{hybrid_mode} = 'efi';
     }
     elsif($arch eq 'i386') {
       $media->{isolinux_cfg} = "boot/i386/loader/isolinux.cfg";
@@ -1020,6 +1152,7 @@ sub get_expected_media_layout
       $media->{efi_image} = "boot/i386/efi";
       $media->{efi_loader} = "EFI/BOOT/bootia32.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+      $media->{hybrid_mode} = 'efi';
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/initrd";
@@ -1027,6 +1160,7 @@ sub get_expected_media_layout
       $media->{bootinfo_txt} = "ppc/bootinfo.txt";
       $media->{grub_cfg} = "boot/grub2/grub.cfg";
       $media->{grub_earlyboot_cfg} = "boot/ppc64le/grub2-ieee1275/grub.cfg";
+      $media->{hybrid_mode} = 'chrp';
     }
     elsif($arch eq 's390x') {
       $media->{initrd} = "boot/s390x/initrd";
@@ -1044,6 +1178,7 @@ sub get_expected_media_layout
       $media->{efi_image} = "boot/x86_64/efi";
       $media->{efi_loader} = "EFI/BOOT/bootx64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+      $media->{hybrid_mode} = 'efi';
     }
   }
   elsif($media->{variant} eq 'live') {
@@ -1058,6 +1193,7 @@ sub get_expected_media_layout
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
+      $media->{hybrid_mode} = 'efi';
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/initrd";
@@ -1065,6 +1201,7 @@ sub get_expected_media_layout
       $media->{bootinfo_txt} = "ppc/bootinfo.txt";
       $media->{grub_cfg} = "boot/grub2/grub.cfg";
       $media->{grub_earlyboot_cfg} = "boot/grub2/powerpc-ieee1275/grub.cfg";
+      $media->{hybrid_mode} = 'chrp';
     }
     elsif($arch eq 's390x') {
       $media->{initrd} = "boot/s390x/initrd";
@@ -1085,6 +1222,7 @@ sub get_expected_media_layout
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
+      $media->{hybrid_mode} = 'efi';
     }
   }
   elsif($media->{variant} eq 'selfinstall') {
@@ -1099,6 +1237,7 @@ sub get_expected_media_layout
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
+      $media->{hybrid_mode} = 'efi';
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/loader/initrd";
@@ -1106,6 +1245,7 @@ sub get_expected_media_layout
       $media->{bootinfo_txt} = "ppc/bootinfo.txt";
       $media->{grub_cfg} = "boot/grub2/grub.cfg";
       $media->{grub_earlyboot_cfg} = "boot/grub2/powerpc-ieee1275/grub.cfg";
+      $media->{hybrid_mode} = 'chrp';
     }
     elsif($arch eq 's390x') {
       $media->{initrd} = "boot/s390x/initrd";
@@ -1126,6 +1266,7 @@ sub get_expected_media_layout
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
+      $media->{hybrid_mode} = 'efi';
     }
   }
 }

--- a/verifymedia
+++ b/verifymedia
@@ -126,6 +126,7 @@ use Digest::MD5;
 use Digest::SHA;
 use File::Path 'make_path';
 use Cwd 'abs_path';
+use JSON;
 
 use Data::Dumper;
 $Data::Dumper::Sortkeys = 1;
@@ -449,8 +450,9 @@ show
   "These files are not needed and should be removed.";
 
 my $sig = chk_signature $media;
+$media->{signature} = $sig if $sig;
 
-print Dumper $sig if $opt_verbose >= 2;
+print "- signature data:\n", Dumper($media->{signature}) if $media->{signature} && $opt_verbose >= 2;
 
 show
   $sig->{block_ok},
@@ -486,6 +488,12 @@ show
   "ISO must be signed.";
 
 print "- $errors error(s)\n" if $opt_verbose >= 1;
+
+my $parti = `parti --json $src`;
+$media->{parti} = decode_json($parti) if $parti;
+
+print "- partition data:\n", Dumper($media->{parti}) if $media->{parti} && $opt_verbose >= 2;
+
 
 exit($errors ? 1 : 0);
 
@@ -781,8 +789,6 @@ sub chk_signature
   }
 
   $sig->{block_is_file} = 1 if $sig->{file_start} && $sig->{block_start} && $sig->{block_start} == $sig->{file_start};
-
-  $media->{signature} = $sig if $sig;
 
   return $sig;
 }

--- a/verifymedia
+++ b/verifymedia
@@ -138,6 +138,17 @@ binmode(STDERR, ":utf8");
 our $VERSION = "0.0";
 our $LIBEXECDIR = "/usr/lib";
 
+use constant {
+  # offset of application specific data (anything goes)
+  ISO9660_APP_DATA_START => 0x8373,
+
+  # application specific data length
+  ISO9660_APP_DATA_LENGTH => 0x200,
+
+  # signature block starts with this string
+  SIGNATURE_MAGIC => "7984fc91-a43f-4e45-bf27-6d3aa08b24cf"
+};
+
 sub usage;
 sub show;
 sub show_and_exit;
@@ -153,11 +164,11 @@ sub chk_treeinfo_arch;
 sub chk_treeinfo_files;
 sub chk_bootinfo;
 sub chk_garbage;
+sub chk_signature;
 
 sub susystem;
 sub get_iso9660_info;
 sub iso_ls;
-sub read_treeinfo;
 sub read_ini;
 sub get_media_style;
 sub get_media_variant;
@@ -166,6 +177,7 @@ sub get_expected_media_layout;
 sub stat_file;
 sub is_dir;
 sub is_file;
+sub read_data;
 sub read_file;
 sub extract_file;
 sub get_grub_root;
@@ -176,6 +188,10 @@ sub file_magic;
 sub unpack_initrd;
 sub get_root_option_initrd;
 sub get_root_option_bootloader;
+sub parse_tag;
+sub get_tag;
+sub set_tag;
+sub read_tags;
 
 my $opt_save_temp;
 my $opt_verbose = 0;
@@ -254,13 +270,15 @@ show
   "all files are owned by root",
   "Files on the ISO image should have uid and gid 0.";
 
-$media->{treeinfo} = read_treeinfo;
+$media->{treeinfo} = read_ini ".treeinfo";
 print "- .treeinfo:\n", Dumper($media->{treeinfo}) if $media->{treeinfo} && $opt_verbose >= 2;
 
 $media->{style} = get_media_style;
 $media->{variant} = get_media_variant;
 $media->{arch} = get_arch;
 get_expected_media_layout $media;
+
+$media->{tags} = read_tags;
 
 print "- media:\n", Dumper($media) if $opt_verbose >= 2;
 die "failed to detect architecture\n" unless $media->{arch};
@@ -289,7 +307,7 @@ show_conditional
   $media->{treeinfo},
   chk_treeinfo_arch($media),
   ".treeinfo architecture matches",
-  "arch entry in general section in .treeinfo must match media architecture.";
+  "'arch' entry in 'general' section in .treeinfo must match media architecture.";
 
 show_conditional
   $media->{treeinfo},
@@ -311,25 +329,25 @@ show_conditional
   $media->{initrd_off},
   chk_file_exists($media->{initrd_off}),
   "initrd.off exists",
-  "initrd.off must exist and have non-zero size.";
+  "'initrd.off' must exist and have non-zero size.";
 
 show_conditional
   $media->{initrd_siz},
   chk_file_exists($media->{initrd_siz}),
   "initrd.siz exists",
-  "initrd.siz must exist and have non-zero size.";
+  "'initrd.siz' must exist and have non-zero size.";
 
 show_conditional
   $media->{cd_ikr},
   chk_file_exists($media->{cd_ikr}),
   "cd.ikr exists",
-  "cd.ikr must exist and have non-zero size.";
+  "'cd.ikr' must exist and have non-zero size.";
 
 show_conditional
   $media->{suse_ins},
   chk_file_exists($media->{suse_ins}),
   "suse.ins exists",
-  "suse.ins must exist and have non-zero size.";
+  "'suse.ins' must exist and have non-zero size.";
 
 show_conditional
   $media->{isolinux_cfg},
@@ -415,19 +433,55 @@ print "- root option: $media->{root_option}\n" if $media->{root_option} && $opt_
 show_conditional
   $media->{variant} eq 'live',
   $media->{root_option} =~ /^live:(?:CD)?LABEL=(.*)/ && $1 eq $iso9660->{volume_id},
-  "ISO label matches dracut live root option",
+  "ISO label matches dracut live 'root' option",
   "ISO label '$iso9660->{volume_id}' must correspond to dracut live root option '$media->{root_option}'.";
 
 show_conditional
   $media->{variant} eq 'selfinstall',
   $media->{root_option} =~ /^install:(?:CD)?LABEL=(.*)/ && $1 eq $iso9660->{volume_id},
-  "ISO label matches kiwi install root option",
+  "ISO label matches kiwi install 'root' option",
   "ISO label '$iso9660->{volume_id}' must correspond to kiwi install root option '$media->{root_option}'.";
 
 show
   chk_garbage($media),
   "no garbage files",
   "These files are not needed and should be removed.";
+
+my $sig = chk_signature $media;
+
+print Dumper $sig if $opt_verbose >= 2;
+
+show
+  $sig->{block_ok},
+  "has tag pointing to signature block",
+  "To be able to sign media, there must be a 'signature' entry in media tag data\n(check with 'tagmedia --show').";
+
+show
+  $sig->{file_ok} ? 1 : 2,
+  "has .signature file",
+  "
+    There should be a '.signature' file to hold the signature.
+    The file (if it exists) must have a size of 2048 bytes and
+    start with the string '${\SIGNATURE_MAGIC}'.
+  ";
+
+show_conditional
+  $sig->{file_ok},
+  $sig->{block_is_file},
+  "signature block and .signature file are identical",
+  "If there is a '.signature' file, the 'signature' tag must point to it.";
+
+my $digest = $sig->{block_digest} || 'sha256';
+
+show
+  $sig->{block_digest} ? $sig->{block_digest} eq 'sha256' ? 1 : 2 : 0,
+  "ISO has $digest digest",
+  "There must be a digest stored in media tag data. Ideally sha256.\n(check with 'tagmedia --show').";
+
+show
+  $sig->{block_signed},
+  "ISO is signed",
+  "ISO must be signed.";
 
 print "- $errors error(s)\n" if $opt_verbose >= 1;
 
@@ -698,6 +752,41 @@ sub chk_garbage
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_signature
+{
+  my $media = $_[0];
+
+  my $sig;
+
+  $sig->{block_digest} = 'md5' if get_tag $media->{tags}, 'md5sum';
+  $sig->{block_digest} = 'sha256' if get_tag $media->{tags}, 'sha256sum';
+
+  my $sig_block = get_tag $media->{tags}, 'signature';
+  if($sig_block) {
+    $sig->{block_start} = $sig_block->{value} * 512;
+    $sig->{block_size} = 2048;
+    $sig->{block_data} = read_data $sig->{block_start}, $sig->{block_size};
+    $sig->{block_ok} = 1 if substr($sig->{block_data}, 0, length(SIGNATURE_MAGIC)) eq SIGNATURE_MAGIC;
+    $sig->{block_signed} = 1 if $sig->{block_data} =~ /PGP SIGNATURE/;
+  }
+
+  my $sig_file = stat_file ".signature";
+  if($sig_file) {
+    $sig->{file_start} = $sig_file->{start} * 2048;
+    $sig->{file_size} = $sig_file->{size};
+    $sig->{file_data} = read_file '.signature';
+    $sig->{file_ok} = 1 if $sig->{file_size} == 2048 && substr($sig->{file_data}, 0, length(SIGNATURE_MAGIC)) eq SIGNATURE_MAGIC;
+  }
+
+  $sig->{block_is_file} = 1 if $sig->{file_start} && $sig->{block_start} && $sig->{block_start} == $sig->{file_start};
+
+  $media->{signature} = $sig if $sig;
+
+  return $sig;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub get_iso9660_info
 {
   my $iso = $_[0];
@@ -837,19 +926,6 @@ sub get_media_variant
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub read_treeinfo
-{
-  my $ini;
-
-  if(extract_file ".treeinfo") {
-    $ini = read_ini ".treeinfo";
-  }
-
-  return $ini;
-}
-
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # read_ini(file)
 #
 # - file: file name
@@ -864,21 +940,19 @@ sub read_ini
   my $ini;
   my $section;
 
-  if(open my $f, "$iso_dir/$file") {
-    while(<$f>) {
-      chomp;
-      s/\s*;.*//;
-      next if /^\s*$/;
-      if(/^\s*\[([^]]+)\]/) {
-        $section = $1;
-        next;
-      }
-      next if !defined $section;
-      if(/^\s*([^=>]+?)\s*+=\s*+(.*?)\s*$/) {
-        $ini->{$section}{$1} = $2;
-      }
+  my $data = read_file $file;
+
+  for (split /\n/, $data) {
+    s/\s*;.*//;
+    next if /^\s*$/;
+    if(/^\s*\[([^]]+)\]/) {
+      $section = $1;
+      next;
     }
-    close $f;
+    next if !defined $section;
+    if(/^\s*([^=>]+?)\s*+=\s*+(.*?)\s*$/) {
+      $ini->{$section}{$1} = $2;
+    }
   }
 
   return $ini;
@@ -1085,20 +1159,17 @@ sub is_file
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Note: uses global var $src.
 #
-sub read_file
+sub read_data
 {
-  my $file = $_[0];
-
-  my $stat = stat_file $file;
-
-  return undef if !defined($stat) || $stat->{type} ne " ";
+  my $start = $_[0];
+  my $size = $_[1];
 
   my $data;
 
   if(open my $fd, $src) {
-    sysseek($fd, $stat->{start} * 2048, 0) or die "$src: seek to block $stat->{start} failed\n";
-    if($stat->{size}) {
-      sysread($fd, $data, $stat->{size}) == $stat->{size} or die "$src: reading $stat->{size} bytes failed\n";
+    sysseek($fd, $start, 0) or die "$src: seek to $start failed\n";
+    if($size) {
+      sysread($fd, $data, $size) == $size or die "$src: reading $size bytes failed\n";
     }
     else {
       $data = "";
@@ -1107,6 +1178,19 @@ sub read_file
   }
 
   return $data;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub read_file
+{
+  my $file = $_[0];
+
+  my $stat = stat_file $file;
+
+  return undef if !defined($stat) || $stat->{type} ne " ";
+
+  return read_data $stat->{start} * 2048, $stat->{size};
 }
 
 
@@ -1567,4 +1651,101 @@ sub get_root_option_bootloader
   return $1 if $grub_cfg =~ /^\s*\$?linux .* root=(\S+)/m;
 
   return undef;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# tag = parse_tag(string)
+#
+# Parse line ('key=value' format) and return hash ref with key/value elements.
+# value is undef if there's no '='.
+#
+sub parse_tag
+{
+  my ($line) = @_;
+
+  $line =~ s/^\s*|\s*$//g;
+
+  if($line =~ /^([A-Z_\d\s]+?)\s*=\s*+(.*)$/i) {
+    return { key => $1, value => $2 };
+  }
+  else {
+    return { key => $line };
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# tag = get_tag(tags, key)
+#
+# Get tag from tag array with specified key.
+# Returns undef if no tag with such a key exists.
+#
+# tags: array ref with tag hashes
+# key: string
+# tag: tag hash ref ('key', 'value' pair)
+#
+sub get_tag
+{
+  my ($tags, $key) = @_;
+
+  for my $tag (@$tags) {
+    return $tag if $tag->{key} eq $key;
+  }
+
+  # try again, case insensitive
+  for my $tag (@$tags) {
+    return $tag if "\L$tag->{key}" eq "\L$key";
+  }
+
+  return undef;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# set_tag(tags, tag)
+#
+# Set tag in tags array.
+#
+# tags: array ref with tag hashes
+# tag: tag hash ref ('key', 'value' pair)
+#
+sub set_tag
+{
+  my ($tags, $tag) = @_;
+
+  my $old_tag = get_tag $tags, $tag->{key};
+  if($old_tag) {
+    $old_tag->{value} = $tag->{value};
+  }
+  else {
+    push @$tags, $tag;
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# tags = read_tags
+#
+# Read existing tags from image fragment.
+#
+# image: hash with image related data
+# image->{blob}: buffer containing a sufficiently large portion of the image (36 kiB)
+# tags: array ref with tags
+# tags are hashes with key/value pairs - value is undef if there's no '='
+#
+sub read_tags
+{
+  my $data = read_data ISO9660_APP_DATA_START, ISO9660_APP_DATA_LENGTH;
+
+  die "unsupported tag format\n" unless $data  =~ /^[0-9A-Za-z_=,;! \x00]{512}$/;
+  $data =~ s/[\s\x00]*$//;
+
+  my $tags = [];
+
+  for my $line (split /;/, $data) {
+    set_tag $tags, parse_tag($line);
+  }
+
+  return $tags;
 }

--- a/verifymedia
+++ b/verifymedia
@@ -1,0 +1,1412 @@
+#! /usr/bin/perl
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# package Tmp version 1.0
+#
+# Create temporary files/directories and ensures they are removed at
+# program end.
+#
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+{
+  package Tmp;
+
+  use File::Temp;
+  use strict 'vars';
+  use Cwd 'abs_path';
+
+  sub new
+  {
+    my $self = {};
+    my $save_tmp = shift;
+
+    bless $self;
+
+    my $x = $0;
+    $x =~ s#.*/##;
+    $x =~ s/(\s+|"|\\|')/_/;
+    $x = 'tmp' if$x eq "";
+
+    my $t = File::Temp::tempdir(abs_path("/tmp") . "/$x.XXXXXXXX", CLEANUP => $save_tmp ? 0 : 1);
+
+    $self->{base} = $t;
+
+    if(!$save_tmp) {
+      my $s_t = $SIG{TERM};
+      $SIG{TERM} = sub { File::Temp::cleanup; &$s_t if $s_t };
+
+      my $s_i = $SIG{INT};
+      $SIG{INT} = sub { File::Temp::cleanup; &$s_i if $s_i };
+    }
+
+    return $self
+  }
+
+  sub dir
+  {
+    my $self = shift;
+    my $dir = shift;
+    my $t;
+
+    if($dir ne "" && !-e("$self->{base}/$dir")) {
+      $t = "$self->{base}/$dir";
+      die "error: mktemp failed\n" unless mkdir $t, 0755;
+    }
+    else {
+      chomp ($t = `mktemp -d $self->{base}/XXXX`);
+      die "error: mktemp failed\n" if $?;
+    }
+
+    return $t;
+  }
+
+  sub file
+  {
+    my $self = shift;
+    my $file = shift;
+    my $t;
+
+    if($file ne "" && !-e("$self->{base}/$file")) {
+      $t = "$self->{base}/$file";
+      open my $f, ">$t";
+      close $f;
+    }
+    else {
+      chomp ($t = `mktemp $self->{base}/XXXX`);
+      die "error: mktemp failed\n" if $?;
+    }
+
+    return $t;
+  }
+
+  # helper function
+  sub umount
+  {
+    my $mp = shift;
+
+    if(open(my $f, "/proc/mounts")) {
+      while(<$f>) {
+        if((split)[1] eq $mp) {
+          # print STDERR "umount $mp\n";
+          ::susystem("umount $mp");
+          return;
+        }
+      }
+      close $f;
+    }
+  }
+
+  sub mnt
+  {
+    my $self = shift;
+    my $dir = shift;
+
+    my $t = $self->dir($dir);
+
+    if($t ne '') {
+      eval 'END { local $?; umount $t }';
+
+      my $s_t = $SIG{TERM};
+      $SIG{TERM} = sub { umount $t; &$s_t if $s_t };
+
+      my $s_i = $SIG{INT};
+      $SIG{INT} = sub { umount $t; &$s_i if $s_i };
+    }
+
+    return $t;
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+use strict;
+use utf8;
+
+use Getopt::Long;
+use Digest::MD5;
+use Digest::SHA;
+use File::Find;
+use File::Path;
+use Cwd 'abs_path';
+
+use Data::Dumper;
+$Data::Dumper::Sortkeys = 1;
+$Data::Dumper::Terse = 1;
+$Data::Dumper::Indent = 1;
+
+binmode(STDOUT, ":utf8");
+binmode(STDERR, ":utf8");
+
+our $VERSION = "0.0";
+our $LIBEXECDIR = "/usr/lib";
+
+sub usage;
+sub show;
+sub show_and_exit;
+sub show_conditional;
+
+sub chk_joliet;
+sub ckh_rockridge;
+sub chk_files_permission;
+sub chk_files_owner;
+sub chk_file_exists;
+sub chk_file_exists_optional;
+sub chk_grub_root_exists;
+
+sub check_root;
+sub susystem;
+sub get_iso9660_info;
+sub unpack_iso_image;
+sub iso_ls;
+sub read_treeinfo;
+sub read_ini;
+sub get_media_style;
+sub get_media_variant;
+sub get_arch;
+sub get_expected_media_layout;
+sub read_file;
+sub get_grub_root;
+sub get_archive_type;
+sub unpack_cpiox;
+sub unpack_archive;
+sub file_magic;
+sub unpack_initrd;
+sub get_live_root;
+
+my $opt_save_temp;
+my $opt_verbose = 0;
+my $opt_mount_iso;
+
+my $config;
+my $tmp;
+my $media;
+my $iso9660;
+my $errors = 0;
+my $error_detail;
+my $src;
+my $src_short;
+my $iso_ls_rockridge;
+my $treeinfo;
+my $iso_dir;
+my $initrd_dir;
+
+Getopt::Long::Configure("gnu_compat");
+
+GetOptions(
+  'mount-iso'        => \$opt_mount_iso,
+  'no-mount-iso'     => sub { $opt_mount_iso = 0 },
+  'save-temp'        => \$opt_save_temp,
+  'verbose|v'        => sub { $opt_verbose++ },
+  'version'          => sub { print "$VERSION\n"; exit 0 },
+  'help'             => sub { usage 0 },
+) || usage 1;
+
+$ENV{PATH} = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+if(open my $f, "$ENV{HOME}/.verifymediarc") {
+  while(<$f>) {
+    next if /^\s*#/;
+    if(/^\s*(\S+?)\s*=\s*(.*?)\s*$/) {
+      my $key = $1;
+      my $val = $2;
+      $val =~ s/^\"|\"$//g;
+      $config->{$key} = $val;
+    }
+  }
+  close $f;
+}
+
+$tmp = Tmp::new($opt_save_temp);
+
+usage 1 unless @ARGV == 1;
+
+$src = shift;
+
+die "$src: no such file\n" unless -f $src;
+die "$src: not readable\n" unless -r _;
+
+($src_short = $src) =~ s#^.*/##;
+print "Verifying: $src_short\n";
+
+$iso9660 = get_iso9660_info $src;
+print "- iso header info:\n", Dumper($iso9660) if $opt_verbose >= 2;
+
+show_and_exit
+  defined($iso9660),
+  "image has ISO-9660 file system",
+  "Image must be using an ISO-9660 file system.";
+
+show
+  chk_rockridge($iso9660),
+  "image uses Rock Ridge extension",
+  "ISO image must use Rock Ridge extension ('mkisofs -R', default in xorriso).";
+
+show
+  chk_joliet($iso9660),
+  "image uses Joliet extension",
+  "ISO image must use Joliet extension ('mkisofs -J', 'xorriso -joliet on').";
+
+$iso_ls_rockridge = iso_ls $src, "rockridge";
+print "- iso file list (rock ridge):\n", Dumper($iso_ls_rockridge) if $opt_verbose >= 2;
+
+$iso_dir = unpack_iso_image $src; 
+
+show
+  chk_files_permission($iso_ls_rockridge),
+  "all files are world-readable",
+  "Files on the ISO image should be readable by all users (chmod o+r).";
+
+show
+  chk_files_owner($iso_ls_rockridge),
+  "all files are owned by root",
+  "Files on the ISO image should have uid and gid 0.";
+
+$treeinfo = read_treeinfo $iso_dir;
+print "- .treeinfo:\n", Dumper($treeinfo) if $opt_verbose >= 2;
+
+$media->{style} = get_media_style $iso_dir;
+$media->{variant} = get_media_variant $iso_dir;
+$media->{arch} = get_arch $iso_dir, $treeinfo;
+get_expected_media_layout $iso_dir, $media;
+
+print "- media:\n", Dumper($media) if $opt_verbose >= 2;
+die "failed to detect architecture\n" unless $media->{arch};
+print "- media style: $media->{style}\n" if $opt_verbose >= 1;
+print "- media variant: $media->{variant}\n" if $opt_verbose >= 1;
+print "- media architecture: $media->{arch}\n" if $opt_verbose >= 1;
+
+show
+  chk_file_exists($iso_dir, $media->{kernel}),
+  "kernel exists",
+  "Kernel must exist and have non-zero size.";
+
+show
+  chk_file_exists($iso_dir, $media->{initrd}),
+  "initrd exists",
+  "Initrd must exist and have non-zero size.";
+
+show_conditional
+  $media->{initrd_off},
+  chk_file_exists($iso_dir, $media->{initrd_off}),
+  "initrd.off exists",
+  "initrd.off must exist and have non-zero size.";
+
+show_conditional
+  $media->{initrd_siz},
+  chk_file_exists($iso_dir, $media->{initrd_siz}),
+  "initrd.siz exists",
+  "initrd.siz must exist and have non-zero size.";
+
+show_conditional
+  $media->{cd_ikr},
+  chk_file_exists($iso_dir, $media->{cd_ikr}),
+  "cd.ikr exists",
+  "cd.ikr must exist and have non-zero size.";
+
+show_conditional
+  $media->{suse_ins},
+  chk_file_exists($iso_dir, $media->{suse_ins}),
+  "suse.ins exists",
+  "suse.ins must exist and have non-zero size.";
+
+show_conditional
+  $media->{isolinux_cfg},
+  chk_file_exists($iso_dir, $media->{isolinux_cfg}),
+  "isolinux config exists",
+  "isolinux.cfg must exist and have non-zero size.";
+
+show_conditional
+  $media->{grub_earlyboot_cfg},
+  chk_file_exists($iso_dir, $media->{grub_earlyboot_cfg}),
+  "grub earlyboot config exists",
+  "earlyboot.cfg must exist and have non-zero size.";
+
+show_conditional
+  $media->{grub_earlyboot_cfg},
+  chk_grub_root_exists($iso_dir, $media->{grub_earlyboot_cfg}),
+  "grub earlyboot config references correct root file system",
+  "$media->{grub_earlyboot_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
+
+show_conditional
+  $media->{grub_cfg},
+  chk_file_exists($iso_dir, $media->{grub_cfg}),
+  "grub config exists",
+  "grub.cfg must exist and have non-zero size.";
+
+show_conditional
+  $media->{grub_cfg},
+  chk_grub_root_exists($iso_dir, $media->{grub_cfg}),
+  "grub config references correct root file system",
+  "$media->{grub_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
+
+show_conditional
+  $media->{efi_grub_cfg},
+  chk_file_exists($iso_dir, $media->{efi_grub_cfg}),
+  "UEFI grub config exists",
+  "UEFI grub.cfg must exist and have non-zero size.";
+
+show_conditional
+  $media->{efi_grub_cfg},
+  chk_grub_root_exists($iso_dir, $media->{efi_grub_cfg}),
+  "UEFI grub config references correct root file system",
+  "$media->{efi_grub_cfg} searches for a specific file to identify its root file system.\nThis file should exist.";
+
+show_conditional
+  $media->{efi_loader},
+  chk_file_exists($iso_dir, $media->{efi_loader}),
+  "UEFI boot loader exists",
+  "UEFI boot loader must exist and have non-zero size.";
+
+show_conditional
+  $media->{efi_image},
+  chk_file_exists_optional($iso_dir, $media->{efi_image}),
+  "UEFI boot image exists",
+  "UEFI boot image should exist and have non-zero size.";
+
+if($media->{variant} eq 'live' && -f "$iso_dir/$media->{initrd}") {
+  $initrd_dir = unpack_initrd $iso_dir, $media->{initrd};
+}
+
+if($media->{variant} eq 'live') {
+  $media->{live_root} = get_live_root $iso_dir, $initrd_dir;
+  print "- live root fs: $media->{live_root}\n" if $media->{live_root} && $opt_verbose >= 1;
+
+  show
+    $media->{live_root} && $media->{live_root} eq "LABEL=$iso9660->{volume_id}",
+    "ISO label matches dracut live root option",
+    "ISO label '$iso9660->{volume_id}' must correspond to dracut live root option '$media->{live_root}'.";
+}
+
+print "- $errors error(s)\n" if $opt_verbose >= 1;
+
+exit($errors ? 1 : 0);
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# usage(exit_code)
+#
+# Print help text and exit with exit_code.
+#
+sub usage
+{
+  print <<"= = = = = = = =";
+Usage: verifymedia ISO
+Verfiy bootable media.
+
+General options:
+
+      --verbose                   Show more detailed messages. Can be repeated to log even more.
+      --version                   Show verifymedia version.
+      --save-temp                 Keep temporary files.
+      --help                      Write this help text.
+
+Debug options:
+      --mount-iso                 Mount ISO images to access them (default if run as root).
+      --no-mount-iso              Unpack ISO images to access them (default if run as normal user).
+
+More information is available in the verifymedia(1) manual page.
+= = = = = = = =
+
+  exit shift;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub show
+{
+  my $result = $_[0];
+  my $topic = $_[1];
+  my $comment = $_[2];
+
+  if(defined $result) {
+    $result++;
+  }
+  else {
+    $result = 0;
+  }
+
+  $errors++ if $result == 1;
+
+  # values: not checked, bad, ok, not nice
+  my @mark = ( "", "\x{2718}", "\x{2714}", "!" );
+
+  my $indent = "";
+  my $indent_c = "  ";
+  
+  printf "${indent}[%-1s] %s\n", $mark[$result], $topic;
+
+  if($result == 1 || $result == 3) {
+    $comment =~ s/\s+$//g;
+    $comment =~ s/^\s*/$indent_c/;
+    $comment =~ s/\n\s*/\n$indent_c/g;
+
+    if($error_detail ne "") {
+      $error_detail =~ s/\s+$//g;
+      $error_detail =~ s/^\s*/$indent_c/;
+      $error_detail =~ s/\n\s*/\n$indent_c/g;
+      print "$error_detail\n";
+    }
+
+    print "$comment\n";
+  }
+
+  undef $error_detail;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub show_and_exit
+{
+  show @_;
+
+  exit 1 if $errors;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub show_conditional
+{
+  return unless $_[0];
+
+  shift;
+
+  show @_;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_joliet
+{
+  my $iso_header = $_[0];
+
+  return $iso_header->{joliet} ? 1 : 0;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_rockridge
+{
+  my $iso_header = $_[0];
+
+  return $iso_header->{rockridge} ? 1 : 0;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_files_permission
+{
+  my $files = $_[0];
+  my $ok = 1;
+
+  for my $file (@$files) {
+    if(substr($file->{perm}, 6, 1) ne 'r') {
+      $error_detail .= sprintf "%s %3d %3d %10d %s\n", $file->{perm}, $file->{uid}, $file->{gid}, $file->{size}, $file->{name};
+      $ok = 0;
+    }
+  }
+
+  return $ok;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_files_owner
+{
+  my $files = $_[0];
+  my $ok = 1;
+
+  for my $file (@$files) {
+    if($file->{uid} != 0 || $file->{gid} != 0) {
+      $error_detail .= sprintf "%s %3d %3d %10d %s\n", $file->{perm}, $file->{uid}, $file->{gid}, $file->{size}, $file->{name};
+      $ok = 0;
+    }
+  }
+
+  return $ok;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_file_exists
+{
+  my $dir = $_[0];
+  my $file = $_[1];
+
+  my $ok = $file ne "" && -s "$dir/$file" ? 1 : 0;
+
+  $error_detail = $file if !$ok;
+
+  return $ok;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_file_exists_optional
+{
+  my $ok = chk_file_exists @_;
+
+  $ok = 2 if !$ok;
+
+  return $ok;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_grub_root_exists
+{
+  my $dir = $_[0];
+  my $grub_cfg = $_[1];
+
+  my $grub_root = get_grub_root $iso_dir, $grub_cfg;
+
+  my $state;
+
+  if($grub_root ne "") {
+    $state = -f "$iso_dir/$grub_root" ? 1 : 0;
+  }
+
+  $error_detail = $grub_root if !$state;
+
+  return $state;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub get_iso9660_info
+{
+  my $iso = $_[0];
+  my $info = `isoinfo -d -i $iso 2>/dev/null`;
+  my $data = {};
+
+  return unless $info =~ /CD-ROM is in ISO 9660 format/;
+
+  $data->{system_id} = $1 if $info =~ /^System id: (.*)/m;
+  $data->{volume_id} = $1 if $info =~ /^Volume id: (.*)/m;
+  $data->{publisher_id} = $1 if $info =~ /^Publisher id: (.*)/m;
+  $data->{application_id} = $1 if $info =~ /^Application id: (.*)/m;
+  $data->{preparer_id} = $1 if $info =~ /^Data preparer id: (.*)/m;
+  $data->{joliet} = 1 if $info =~ /^Joliet .* found/m;
+  $data->{rockridge} = 1 if $info =~ /^Rock Ridge .* found/m;
+  $data->{eltorito} = $1 if $info =~ /^El Torito .* found, boot catalog is in sector (\d+)/m;
+
+  print "- iso header info:\n", Dumper($iso9660) if $opt_verbose >= 2;
+
+  return $data;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub unpack_iso_image
+{
+  my $iso = $_[0];
+
+  my $dir;
+
+  $opt_mount_iso = check_root if ! defined $opt_mount_iso;
+  if($opt_mount_iso) {
+    check_root "Sorry, can't access ISO images; you need root privileges.";
+    print "- mounting $iso\n" if $opt_verbose >= 1;
+    $dir = $tmp->mnt("iso");
+    susystem "mount -oro,loop $iso $dir";
+  }
+  else {
+    print "- unpacking $iso\n" if $opt_verbose >= 1;
+    $dir = $tmp->dir();
+    system "cd $dir && isoinfo -i '" . abs_path($iso) . "' -RJX 2>/dev/null && chmod -R a=r,a=rX,u+w ."
+      and die "$iso: ISO unpacking failed\n";
+  }
+
+  return $dir;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ISO file list sorted by start address.
+#
+# Return ref to array with files.
+#
+sub iso_ls
+{
+  my $iso = $_[0];
+  my $extension = $_[1];
+  my $files;
+
+  if($extension eq "joliet") {
+    $extension = "-J";
+  }
+  elsif($extension eq "rockridge") {
+    $extension = "-R";
+  }
+  else {
+    $extension = "";
+  }
+
+  open my $fd, "isoinfo $extension -l -i $iso 2>/dev/null |";
+
+  my $dir = "/";
+
+  while(<$fd>) {
+    if(/^Directory listing of\s*(\/.*\/)/) {
+      $dir = $1;
+      next;
+    }
+
+    # isoinfo format change
+    # cf. https://sourceforge.net/p/cdrtools/mailman/message/35173024
+    s/^\s*\d+\s+//;
+
+    if(/^(.)(.*)\s\[\s*(\d+)(\s+\d+)?\]\s+(.*?)\s*$/) {
+      my $type = $1;
+      my @x = split ' ', $2;
+      $type = ' ' if $type eq '-';
+      if($5 ne '.' && $5 ne '..') {
+        my $start = $3 + 0;
+        my $name = "$dir$5";
+        $name =~ s#^/##;
+        $name =~ s/\.?\;1$// if !$extension;
+        push @$files, { name => $name, type => $type, start => $start, perm => $x[0], uid => $x[2], gid => $x[3], size => $x[4] };
+      }
+    }
+  }
+
+  close $fd;
+
+  $files = [ sort { $a->{start} <=> $b->{start} } @$files ] if $files;
+
+  return $files;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# check_root(msg)
+#
+# Checks if we can get root privileges if required.
+#
+# - msg: message to show to user if things fail
+#        if msg is not set, return status whether running as root is possible
+#
+sub check_root
+{
+  my $p;
+  my $msg = shift;
+
+  if(!$config->{sudo_checked}) {
+    $config->{sudo_checked} = 1;
+
+    $config->{check_root_ok} = 0;
+    if(!$>) {
+      delete $config->{sudo};
+      $config->{check_root_ok} = 1;
+    }
+    else {
+      my $p;
+      chomp($p = `bash -c 'type -p $config->{sudo}'`) if $config->{sudo};
+      $config->{check_root_ok} = 1 if $p ne "";
+    }
+  }
+
+  die "$msg\n" if !$config->{check_root_ok} && $msg;
+
+  return $config->{check_root_ok};
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# susystem(cmd)
+#
+# Run command with root privileges.
+#
+# - cmd: command to run
+#
+sub susystem
+{
+  system "$config->{sudo} $_[0]";
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------------
+
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# get_media_style(sources)
+#
+# - sources: array_ref containing a list of directories
+#
+# Look at sources and determine media style (suse vs. rh).
+#
+# Assume rh style if there's an '/isolinux' dir or a '.discinfo' file or
+# there are '<FOO>/Packages' subdirectories.
+#
+# FIXME: Ferdora Live is reported as 'suse'.
+#
+sub get_media_style
+{
+  my $dir = $_[0];
+
+  if(-d "$dir/isolinux" || -f "$dir/.discinfo") {
+    return 'rh';
+  }
+
+  for my $file (glob "$dir/*/Packages") {
+    return 'rh' if -d $file;
+  }
+
+  return 'suse';
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# get_media_variant(sources)
+#
+# - sources: array_ref containing a list of directories
+#
+# Look at sources and determine media variant (install vs. live).
+#
+# Assume a Live medium if there's an '/LiveOS' dir.
+#
+sub get_media_variant
+{
+  my $dir = $_[0];
+
+  return 'live' if -d "$dir/LiveOS";
+  return 'selfinstall' if -f "$dir/config.isoclient";
+
+  return 'install';
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub read_treeinfo
+{
+  my $dir = $_[0];
+
+  my $ini = read_ini "$dir/.treeinfo";
+
+  return $ini;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# read_ini(file)
+#
+# - file: file name
+#
+# Read ini-style config file.
+#
+# Return content as hash reference.
+#
+sub read_ini
+{
+  my $file = $_[0];
+  my $ini;
+  my $section;
+
+  if(open my $f, $file) {
+    while(<$f>) {
+      chomp;
+      s/\s*;.*//;
+      next if /^\s*$/;
+      if(/^\s*\[([^]]+)\]/) {
+        $section = $1;
+        next;
+      }
+      next if !defined $section;
+      if(/^\s*([^=>]+?)\s*+=\s*+(.*?)\s*$/) {
+        $ini->{$section}{$1} = $2;
+      }
+    }
+    close $f;
+  }
+
+  return $ini;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub get_arch
+{
+  my $dir = $_[0];
+  my $treeinfo = $_[1];
+
+  my $arch;
+
+  # Note: .treeinfo is broken on SUSE media
+  #
+  # if($treeinfo) {
+  #   return $treeinfo->{general}{arch} if $treeinfo->{general} && $treeinfo->{general}{arch};
+  # }
+
+  for my $x ('aarch64', 'i386', 'ppc64', 'ppc64le', 's390x', 'x86_64') {
+    return $x if -d "$dir/boot/$x";
+  }
+
+  return $arch;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub get_expected_media_layout
+{
+  my $dir = $_[0];
+  my $media = $_[1];
+
+  my $arch = $media->{arch};
+
+  return unless $arch;
+
+  if($media->{variant} eq 'install') {
+    if($arch eq 'aarch64') {
+      $media->{initrd} = "boot/aarch64/initrd";
+      $media->{kernel} = "boot/aarch64/linux";
+      $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
+      $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+    }
+    elsif($arch eq 'ppc64le') {
+      $media->{initrd} = "boot/ppc64le/initrd";
+      $media->{kernel} = "boot/ppc64le/linux";
+    }
+    elsif($arch eq 's390x') {
+      $media->{initrd} = "boot/s390x/initrd";
+      $media->{initrd_off} = "boot/s390x/initrd.off";
+      $media->{initrd_siz} = "boot/s390x/initrd.siz";
+      $media->{kernel} = "boot/s390x/linux";
+      $media->{cd_ikr} = "boot/s390x/cd.ikr";
+      $media->{suse_ins} = "boot/s390x/suse.ins";
+    }
+    elsif($arch eq 'x86_64') {
+      $media->{isolinux_cfg} = "boot/x86_64/loader/isolinux.cfg";
+      $media->{el_torito_image} = "boot/x86_64/loader/isolinux.bin";
+      $media->{initrd} = "boot/x86_64/loader/initrd";
+      $media->{kernel} = "boot/x86_64/loader/linux";
+      $media->{efi_image} = "boot/x86_64/efi";
+      $media->{efi_loader} = "EFI/BOOT/bootx64.efi";
+      $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+    }
+  }
+  elsif($media->{variant} eq 'live') {
+    if($arch eq 'aarch64') {
+      $media->{grub_cfg} = "boot/grub2/grub.cfg";
+      $media->{initrd} = "boot/aarch64/loader/initrd";
+      $media->{kernel} = "boot/aarch64/loader/linux";
+      $media->{efi_image} = "boot/aarch64/loader/efiboot.img";
+      $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
+      $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+      if(open my $fd, "$dir/boot/mbrid") {
+        my $id = <$fd>;
+        close $fd;
+        chomp $id;
+        if($id && -f "$dir/boot/$id") {
+          $media->{grub_search_id} = "/boot/$id";
+        }
+      }
+    }
+    elsif($arch eq 'ppc64le') {
+      $media->{initrd} = "boot/ppc64le/initrd";
+      $media->{kernel} = "boot/ppc64le/linux";
+    }
+    elsif($arch eq 's390x') {
+      $media->{initrd} = "boot/s390x/initrd";
+      $media->{initrd_off} = "boot/s390x/initrd.off";
+      $media->{initrd_siz} = "boot/s390x/initrd.siz";
+      $media->{kernel} = "boot/s390x/linux";
+      $media->{cd_ikr} = "boot/s390x/cd.ikr";
+      $media->{suse_ins} = "boot/s390x/suse.ins";
+    }
+    elsif($arch eq 'x86_64') {
+      $media->{grub_cfg} = "boot/grub2/grub.cfg";
+      $media->{grub_earlyboot_cfg} = "boot/grub2/earlyboot.cfg";
+      $media->{el_torito_image} = "boot/x86_64/loader/eltorito.img";
+      $media->{initrd} = "boot/x86_64/loader/initrd";
+      $media->{kernel} = "boot/x86_64/loader/linux";
+      $media->{efi_image} = "boot/x86_64/loader/efiboot.img";
+      $media->{efi_loader} = "EFI/BOOT/bootx64.efi";
+      $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+      if(open my $fd, "$dir/boot/mbrid") {
+        my $id = <$fd>;
+        close $fd;
+        chomp $id;
+        if($id && -f "$dir/boot/$id") {
+          $media->{grub_search_id} = "/boot/$id";
+        }
+      }
+    }
+  }
+  elsif($media->{variant} eq 'selfinstall') {
+    if($arch eq 'aarch64') {
+      $media->{grub_cfg} = "boot/grub2/grub.cfg";
+      $media->{initrd} = "boot/aarch64/loader/initrd";
+      $media->{kernel} = "boot/aarch64/loader/linux";
+      $media->{efi_image} = "boot/aarch64/loader/efiboot.img";
+      $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
+      $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+      if(open my $fd, "$dir/boot/mbrid") {
+        my $id = <$fd>;
+        close $fd;
+        chomp $id;
+        if($id && -f "$dir/boot/$id") {
+          $media->{grub_search_id} = "/boot/$id";
+        }
+      }
+    }
+    elsif($arch eq 'ppc64le') {
+      $media->{initrd} = "boot/ppc64le/initrd";
+      $media->{kernel} = "boot/ppc64le/linux";
+    }
+    elsif($arch eq 's390x') {
+      $media->{initrd} = "boot/s390x/initrd";
+      $media->{initrd_off} = "boot/s390x/initrd.off";
+      $media->{initrd_siz} = "boot/s390x/initrd.siz";
+      $media->{kernel} = "boot/s390x/linux";
+      $media->{cd_ikr} = "boot/s390x/cd.ikr";
+      $media->{suse_ins} = "boot/s390x/suse.ins";
+    }
+    elsif($arch eq 'x86_64') {
+      $media->{grub_cfg} = "boot/grub2/grub.cfg";
+      $media->{grub_earlyboot_cfg} = "boot/grub2/earlyboot.cfg";
+      $media->{el_torito_image} = "boot/x86_64/loader/eltorito.img";
+      $media->{initrd} = "boot/x86_64/loader/initrd";
+      $media->{kernel} = "boot/x86_64/loader/linux";
+      $media->{efi_image} = "boot/x86_64/loader/efiboot.img";
+      $media->{efi_loader} = "EFI/BOOT/bootx64.efi";
+      $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
+      if(open my $fd, "$dir/boot/mbrid") {
+        my $id = <$fd>;
+        close $fd;
+        chomp $id;
+        if($id && -f "$dir/boot/$id") {
+          $media->{grub_search_id} = "/boot/$id";
+        }
+      }
+    }
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub read_file
+{
+  my $dir = $_[0];
+  my $file = $_[1];
+
+  my $data;
+
+  if(open my $fd, "$dir/$file") {
+    local $/;
+    $data = <$fd>;
+    close $fd;
+  }
+
+  return $data;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub get_grub_root
+{
+  my $dir = $_[0];
+  my $file = $_[1];
+
+  my $data = read_file $dir, $file;
+
+  my $root;
+
+  if($data) {
+    # search --file --set=root /boot/0x11cebed2
+    # search --no-floppy --file /boot/aarch64/efi --set
+    if($data =~ /^search .*--set=root \/(\S+)/m) {
+      $root = $1;
+    }
+    elsif($data =~ /^search .*--file \/(\S+) .*--set/m) {
+      $root = $1;
+    }
+  }
+
+  return $root;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Get archive type;
+#
+# type = get_archive_type(file)
+#
+# - file: the archive name
+# - type: something like 'tar.xz' or undef if the archive is unsupported.
+#
+sub get_archive_type
+{
+  my $file = $_[0];
+  my $type;
+  my $cmd;
+
+  my $orig = $file;
+
+  if(-d $file) {
+    return 'dir';
+  }
+
+  if(! -f $file) {
+    return undef;
+  }
+
+  if(! -r $file) {
+    die "$orig: not readable; you need root privileges.\n";
+  }
+
+  do {
+    my $t = file_magic $file, $cmd;
+
+    if($t =~ /^RPM/) {
+      $type = "cpio.rpm$type";
+    }
+    elsif($t =~ /^ASCII cpio archive \(SVR4/) {
+      $type = "cpiox$type";
+    }
+    elsif($t =~ /\b(cpio|tar) archive/) {
+      $type = "$1$type";
+    }
+    elsif($t =~ /^(gzip|XZ|Zstandard) compressed data/) {
+      my $c = "\L$1";
+      $c =~ s/zstandard/zstd/;
+      if($cmd) {
+        $cmd .= " | $c --quiet -dc";
+      }
+      else {
+        $cmd = "$c --quiet -dc '$file'";
+      }
+      $file = "-";
+      $c =~ s/gzip/gz/;
+      $c =~ s/zstd/zst/;
+      $type = ".$c$type";
+    }
+    else {
+      die "$orig: unsupported archive format\n";
+    }
+  } while($type =~ /^\./);
+
+  # print "$file = $type\n";
+
+  return $type;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Unpack multiple concatenated cpio archives.
+#
+# The archives are expected to be in cpio ASCII format ('cpio -H newc').
+# Between the idividual archives an arbitrary sequence of (binary) zeros is
+# allowed. (This is what the kernel allows for the initramfs image.)
+#
+# unpack_cpiox(dst, file, part)
+#
+# -  dst: the directory to unpack to
+# - file: the archive file name
+# - part: the part number (1 based) of a multipart archive (0 = unpack all)
+#
+sub unpack_cpiox
+{
+  my $dst = shift;
+  my $file = shift;
+  my $part = shift() + 0;
+
+  my $cpio_cmd = 'cpio --quiet -dmiu --sparse --no-absolute-filenames 2>/dev/null';
+
+  # the archive number we are looking for (1 based)
+  my $cnt = 1;
+
+  # input and output file handles
+  my ($f, $p);
+
+  # data transfer buffer
+  my $buf;
+
+  # search for cpio header in input stream on next read operation
+  my $sync = 0;
+
+  # track # of written bytes (reset at start of each cpio archive)
+  my $write_ofs;
+
+  # Read # of bytes from input and write to output.
+  #
+  # bytes = $read_write->(len)
+  # -   len: number of bytes to transfer
+  # - bytes: size of data actually transferred
+  #
+  # This function implicitly opens a new output pipe if none is open and data
+  # need to be written.
+  #
+  # If the $sync variable is set search the input stream for a valid cpio
+  # header (and reset $sync to 0).
+  #
+  my $read_write = sub
+  {
+    my $len = $_[0];
+
+    # nothing to do
+    return $len if !$len;
+
+    # clear buffer
+    undef $buf;
+
+    # Search for next cpio header.
+    #
+    # This assumes there's a number of binary zeros in the input stream
+    # until the next cpio header.
+    # Actually this only looks for the next non-zero data blob.
+    if($sync) {
+      $sync = 0;
+      while(sysread($f, $buf, 1) == 1 && $buf eq "\x00") {};
+      $len -= length $buf;
+    }
+
+    # read $len bytes
+    while($len) {
+      my $x = sysread $f, substr($buf, length $buf), $len;
+      last if !$x;
+      $len -= $x;
+    };
+
+    # In case we did read something, write it to output pipe.
+    if(length $buf) {
+      # Open a new pipe if needed.
+      # But only if part number matches or is 0 (== all parts).
+      if(!$p && ($part == 0 || $part == $cnt)) {
+        open $p, "| ( cd $dst ; $cpio_cmd )" or die "failed to open cpio: $!\n";
+        $write_ofs = 0;
+      }
+
+      # Write data and track output size for padding calculation at the end.
+      if($p) {
+        syswrite $p, $buf;
+        $write_ofs += length $buf;
+      }
+    }
+
+    return length $buf;
+  };
+
+  # Write padding bytes (pad with 0 to full 512 byte blocks) and close
+  # output pipe.
+  #
+  # $write_pad_and_close->()
+  #
+  # This also sets a sync flag indicating that we should search for the next
+  # valid cpio header in the input stream.
+  #
+  my $write_pad_and_close = sub
+  {
+    if($p) {
+      my $pad = (($write_ofs + 0x1ff) & ~0x1ff) - $write_ofs;
+      syswrite $p, "\x00" x $pad, $pad if $pad;
+      close $p;
+      undef $p;
+    }
+
+    # search for next cpio header in input stream
+    $sync = 1;
+  };
+
+  # open archive and get going...
+  if(open $f, $file) {
+    my $len;
+
+    # We have to trace the cpio archive structure.
+    # Keep going as long as there's a header.
+    while(($len = $read_write->(110)) == 110) {
+      my $magic = substr($buf, 0, 6);
+      my $head = substr($buf, 6);
+
+      my $fname_len = hex substr $buf, 94, 8;
+      my $data_len = hex substr $buf, 54, 8;
+
+      die "broken cpio header\n" if $magic !~ /^07070[12]$/;
+
+      $fname_len += (2, 1, 0, 3)[$fname_len & 3];
+      $data_len = (($data_len + 3) & ~3);
+
+      $read_write->($fname_len);
+
+      my $fname = $buf;
+      $fname =~ s/\x00*$//;
+
+      $read_write->($data_len);
+
+      # Look for cpio archive end marker.
+      # If found, close cpio process. A new process will be started at the
+      # next valid cpio archive header.
+      if(
+        $fname eq 'TRAILER!!!' &&
+        $head =~ /^0{39}10{55}b0{8}$/i
+      ) {
+        $write_pad_and_close->();
+        # exit if we're done
+        if($cnt++ == $part) {
+          close $f;
+          return;
+        }
+      }
+    }
+
+    # we're done, close input file...
+    close $f;
+
+    # ...and output file.
+    $write_pad_and_close->();
+
+    # If $len is != 0 this means we've seen something that's not a header of
+    # a cpio archive entry.
+    die "invalid cpio data\n" if $len;
+  }
+  else {
+    die "error reading cpio archive: $!\n";
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Unpack archive file.
+#
+# unpack_archive(type, file, dir, part)
+#
+# - type: a type string as returned by get_archive_type
+# - file: the archive
+# -  dir: the directory to unpack to
+# - part: is the part number of a multipart archive (0 = unpack all)
+#
+sub unpack_archive
+{
+  my $type = $_[0];
+  my $file = $_[1];
+  my $dir = $_[2];
+  my $part = $_[3];
+
+  return undef if $type eq '';
+
+  my $cmd;
+  my $cpiox;
+
+  if($type eq 'dir') {
+    $cmd = "tar -C '$file' -cf - .";
+    $type = 'tar';
+  }
+  elsif(! -r $file) {
+    die "$file: not readable; you need root privileges.\n";
+  }
+
+  for (reverse split /\./, $type) {
+    if(/^(gz|xz|zst|rpm)$/) {
+      my $c;
+      if($1 eq 'gz') {
+        $c = 'gzip --quiet -dc';
+      }
+      elsif($1 eq 'xz') {
+        $c = 'xz --quiet -dc';
+      }
+      elsif($1 eq 'zst') {
+        $c = 'zstd --quiet -dc';
+      }
+      else {
+        $c = 'rpm2cpio';
+      }
+      if($cmd) {
+        $cmd .= " | $c";
+      }
+      else {
+        $cmd = "$c '$file'";
+      }
+    }
+    elsif($_ eq 'tar') {
+      $cmd = "cat '$file'" if !$cmd;
+      $cmd .= " | tar -C '$dir' --keep-directory-symlink -xpf - 2>/dev/null";
+      last;
+    }
+    elsif($_ eq 'cpio') {
+      $cmd = "cat '$file'" if !$cmd;
+      $cmd .= " | ( cd '$dir' ; cpio --quiet -dmiu --sparse --no-absolute-filenames 2>/dev/null )";
+      last;
+    }
+    elsif($_ eq 'cpiox') {
+      if(!$cmd) {
+        $cmd = $file;
+      }
+      else {
+        $cmd .= " |";
+      }
+      $cpiox = 1;
+      last;
+    }
+  }
+
+  # cpiox = concatenated compressed cpio archives as the kernel uses for initrd
+  # must be SVR4 ASCII format, with or without CRC ('cpio -H newc')
+  # in this case we have to parse the cpio stream and handle the 'TRAILER!!!' entries
+  if($cpiox) {
+    # print STDERR "unpack_cpiox($cmd)\n";
+    unpack_cpiox $dir, $cmd, $part;
+  }
+  else {
+    # print STDERR "$cmd\n";
+    system $cmd;
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Run 'file' system command.
+#
+# result = file_magic(file, pipe)
+#
+# -   file: the input file, or '-' if pipe is set
+# -   pipe: (if set) the command to read from
+# - result: everything 'file' returns
+#
+sub file_magic
+{
+  my $type = "file -b -k -L $_[0] 2>/dev/null";
+  $type = "$_[1] | $type" if $_[1];
+
+  return `$type`;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub unpack_initrd
+{
+  my $dir = $_[0];
+  my $file = $_[1];
+
+  return undef unless $file;
+
+  my $tmp_dir = $tmp->dir('initrd');
+
+  my $type = get_archive_type "$dir/$file";
+
+  if($type) {
+    unpack_archive $type, "$dir/$file", $tmp_dir;
+  }
+  else {
+    die "$dir: initrd unpacking failed\n";
+  }
+
+  return $tmp_dir;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub get_live_root
+{
+  my $iso = $_[0];
+  my $initrd = $_[1];
+
+  return undef unless $initrd;
+
+  return undef unless -d "$initrd/etc/cmdline.d";
+
+  my $config = `cat $initrd/etc/cmdline.d/*.conf`;
+
+  return $1 if $config =~ /^root=live:(\S+)/m;
+
+  return undef;
+}

--- a/verifymedia
+++ b/verifymedia
@@ -161,7 +161,6 @@ sub ckh_rockridge;
 sub chk_files_permission;
 sub chk_files_owner;
 sub chk_file_exists;
-sub chk_file_exists_optional;
 sub chk_treeinfo_arch;
 sub chk_treeinfo_files;
 sub chk_bootinfo;
@@ -169,6 +168,7 @@ sub chk_garbage;
 sub chk_signature;
 sub chk_hybrid_chrp;
 sub chk_hybrid_efi;
+sub chk_eltorito;
 
 sub susystem;
 sub get_iso9660_info;
@@ -199,6 +199,12 @@ sub read_tags;
 
 my $opt_save_temp;
 my $opt_verbose = 0;
+my $opt_ignore;
+my $opt_ignore_list = [
+  "UEFI boot image exists",
+  "ISO digest is md5",
+  "boot partition is EFI System Partition"
+];
 
 my $tmp;
 my $media;
@@ -215,17 +221,20 @@ my $initrd_dir;
 Getopt::Long::Configure("gnu_compat");
 
 GetOptions(
+  'ignore=s{1,}'     => \@$opt_ignore_list,
   'save-temp'        => \$opt_save_temp,
   'verbose|v'        => sub { $opt_verbose++ },
   'version'          => sub { print "$VERSION\n"; exit 0 },
   'help'             => sub { usage 0 },
 ) || usage 1;
 
-$ENV{PATH} = "/usr/bin:/bin:/usr/sbin:/sbin";
+$ENV{PATH} = "$LIBEXECDIR/mksusecd:/usr/bin:/bin:/usr/sbin:/sbin";
 
 $tmp = Tmp::new($opt_save_temp);
 
 usage 1 unless @ARGV == 1;
+
+$opt_ignore->{$_} = 1 for @$opt_ignore_list;
 
 $src = shift;
 
@@ -422,7 +431,7 @@ show_conditional
 
 show_conditional
   $media->{efi_image},
-  chk_file_exists_optional($media->{efi_image}),
+  chk_file_exists($media->{efi_image}),
   "UEFI boot image exists",
   "UEFI boot image should exist and have non-zero size.";
 
@@ -438,13 +447,13 @@ print "- root option: $media->{root_option}\n" if $media->{root_option} && $opt_
 show_conditional
   $media->{variant} eq 'live',
   $media->{root_option} =~ /^live:(?:CD)?LABEL=(.*)/ && $1 eq $iso9660->{volume_id},
-  "ISO label matches dracut live 'root' option",
+  "ISO label matches dracut live root option",
   "ISO label '$iso9660->{volume_id}' must correspond to dracut live root option '$media->{root_option}'.";
 
 show_conditional
   $media->{variant} eq 'selfinstall',
   $media->{root_option} =~ /^install:(?:CD)?LABEL=(.*)/ && $1 eq $iso9660->{volume_id},
-  "ISO label matches kiwi install 'root' option",
+  "ISO label matches kiwi install root option",
   "ISO label '$iso9660->{volume_id}' must correspond to kiwi install root option '$media->{root_option}'.";
 
 show
@@ -452,19 +461,18 @@ show
   "no garbage files",
   "These files are not needed and should be removed.";
 
+my $parti = `parti --json $src`;
+$media->{parti} = decode_json($parti) if $parti;
+
+print "- partition data:\n", Dumper($media->{parti}) if $media->{parti} && $opt_verbose >= 2;
+
 if($media->{hybrid_mode}) {
-  my $parti = `parti --json $src`;
-  $media->{parti} = decode_json($parti) if $parti;
-
-  print "- partition data:\n", Dumper($media->{parti}) if $media->{parti} && $opt_verbose >= 2;
-
   my $hybrid;
 
   $hybrid = chk_hybrid_chrp($media) if $media->{hybrid_mode} eq 'chrp';
   $hybrid = chk_hybrid_efi($media) if $media->{hybrid_mode} eq 'efi';
-  $media->{hybrid} = $hybrid if $hybrid;
 
-  print "- hybrid data:\n", Dumper($media->{hybrid}) if $media->{hybrid} && $opt_verbose >= 2;
+  print "- hybrid data:\n", Dumper($hybrid) if $hybrid && $opt_verbose >= 2;
 
   if($media->{hybrid_mode} eq 'efi') {
     show
@@ -474,8 +482,14 @@ if($media->{hybrid_mode}) {
 
     show
       $hybrid && $hybrid->{efi_partition},
-      "has EFI System Partition with VFAT file system",
-      "To be UEFI bootable, there must be an EFI System Partition.";
+      "has boot partition with VFAT file system",
+      "To be UEFI bootable, there must be a VFAT boot partition.";
+
+    show_conditional
+      $hybrid && $hybrid->{efi_partition},
+      $hybrid->{efi_partition_is_esp},
+      "boot partition is EFI System Partition",
+      "The boot partition type should be EFI System Partition.";
 
     show
       $hybrid && $hybrid->{data_partition},
@@ -509,8 +523,28 @@ if($media->{hybrid_mode}) {
       "no invalid partition entries",
       "Other partition table entries must have valid data or be completely empty.";
   }
-
 }
+
+my $eltorito = chk_eltorito($media);
+print "- el torito data:\n", Dumper($eltorito) if $eltorito && $opt_verbose >= 2;
+
+show_conditional
+  $media->{eltorito_legacy},
+  $eltorito->{legacy},
+  "El Torito legacy bootable",
+  "ISO boot catalog must have El Torito entry for legacy boot (pointing to grub or isolinux).";
+
+show_conditional
+  $media->{eltorito_efi},
+  $eltorito->{efi},
+  "El Torito UEFI bootable",
+  "ISO boot catalog must have El Torito entry for an EFI System Partition image.";
+
+show_conditional
+  $media->{eltorito_s390x},
+  $eltorito->{s390x},
+  "El Torito S390X bootable",
+  "ISO boot catalog must have El Torito entry for an S390X IKR image.";
 
 my $sig = chk_signature $media;
 $media->{signature} = $sig if $sig;
@@ -520,11 +554,11 @@ print "- signature data:\n", Dumper($media->{signature}) if $media->{signature} 
 show
   $sig->{block_ok},
   "has tag pointing to signature block",
-  "To be able to sign media, there must be a 'signature' entry in media tag data\n(check with 'tagmedia --show').";
+  "To be able to sign media, there must be a 'signature' entry in media tag data\n(check settings with 'tagmedia --show').";
 
 show_conditional
   $media->{expect_signature_file},
-  $sig->{file_ok} ? 1 : 2,
+  $sig->{file_ok},
   "has .signature file",
   "
     There should be a '.signature' file to hold the signature.
@@ -538,12 +572,16 @@ show_conditional
   "signature block and .signature file are identical",
   "If there is a '.signature' file, the 'signature' tag must point to it.";
 
-my $digest = $sig->{block_digest} || 'sha256';
-
 show
-  $sig->{block_digest} ? $sig->{block_digest} eq 'sha256' ? 1 : 2 : 0,
-  "ISO has $digest digest",
-  "There must be a digest stored in media tag data. Ideally sha256.\n(check with 'tagmedia --show').";
+  $sig->{block_digest},
+  "ISO has digest",
+  "There must be a digest stored in media tag data. Ideally sha256 or sha512.\n(check settings with 'tagmedia --show').";
+
+show_conditional
+  $sig->{block_digest},
+  $sig->{block_digest} eq 'sha256' || $sig->{block_digest} eq 'sha512',
+  "ISO digest is $sig->{block_digest}",
+  "Prefer a secure digest like sha256 or sha512.\n(check settings with 'tagmedia --show').";
 
 show
   $sig->{block_signed},
@@ -565,14 +603,16 @@ sub usage
 {
   print <<"= = = = = = = =";
 Usage: verifymedia ISO
-Verfiy bootable media.
+Verify SUSE installation media.
 
-General options:
-
-      --verbose                   Show more detailed messages. Can be repeated to log even more.
+      --ignore TOPIC_LIST         Ignore specific test results. The test is still run but any failures
+                                  are not counted.
+      --verbose                   Increase log level.
       --version                   Show verifymedia version.
       --save-temp                 Keep temporary files.
       --help                      Write this help text.
+
+Program exit code is 0 if no errors were found and != 0 in case of errors.
 
 More information is available in the verifymedia(1) manual page.
 = = = = = = = =
@@ -588,7 +628,7 @@ sub show
   my $topic = $_[1];
   my $comment = $_[2];
 
-  $result += 0;
+  $result = $result ? 1 : $opt_ignore->{$topic} ? 2 : 0;
 
   $errors++ if $result == 0;
 
@@ -705,17 +745,6 @@ sub chk_file_exists
   my $ok = $stat && $stat->{size} > 0 ? 1 : 0;
 
   $error_detail = $file if !$ok;
-
-  return $ok;
-}
-
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub chk_file_exists_optional
-{
-  my $ok = chk_file_exists @_;
-
-  $ok = 2 if !$ok;
 
   return $ok;
 }
@@ -906,11 +935,10 @@ sub chk_hybrid_efi
   if($partitions) {
     for my $p (@$partitions) {
       $hybrid->{invalid_partition} = 1, next if $hybrid->{mbr} && !$p->{attributes}{valid};
-      $hybrid->{efi_partition} = 1 if
-        $p->{first_lba} != 0 &&
-        ($p->{type_name} eq "efi" || $p->{type_name} eq "efi system") &&
-        $p->{filesystem} &&
-        $p->{filesystem}{type} eq 'vfat';
+      if($p->{first_lba} != 0 && $p->{filesystem} && $p->{filesystem}{type} eq 'vfat') {
+        $hybrid->{efi_partition} = 1;
+        $hybrid->{efi_partition_is_esp} = 1 if $p->{type_name} eq "efi" || $p->{type_name} eq "efi system";
+      }
       $hybrid->{data_partition} = 1 if
         $p->{first_lba} != 0 &&
         $p->{filesystem} &&
@@ -922,6 +950,29 @@ sub chk_hybrid_efi
   }
 
   return $hybrid;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+sub chk_eltorito
+{
+  my $media = $_[0];
+  my $eltorito;
+
+  my $parti = $media->{parti};
+
+  return unless $parti;
+
+  if($parti->{eltorito}) {
+    for my $c (@{$parti->{eltorito}{catalog}}) {
+      next if $c->{media_type} ne 'no emulation';
+      $eltorito->{legacy} = 1, next if $c->{boot_info_table};
+      $eltorito->{efi} = 1, next if $c->{filesystem} && $c->{filesystem}{type} eq 'vfat';
+      $eltorito->{s390x} = 1 if $c->{s390x_parm} || $c->{file_name} =~ /\.ikr$/;
+    }
+  }
+
+  return $eltorito;
 }
 
 
@@ -1143,6 +1194,7 @@ sub get_expected_media_layout
       $media->{efi_loader} = "EFI/BOOT/bootaa64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
       $media->{hybrid_mode} = 'efi';
+      $media->{eltorito_efi} = 1;
     }
     elsif($arch eq 'i386') {
       $media->{isolinux_cfg} = "boot/i386/loader/isolinux.cfg";
@@ -1153,6 +1205,8 @@ sub get_expected_media_layout
       $media->{efi_loader} = "EFI/BOOT/bootia32.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
       $media->{hybrid_mode} = 'efi';
+      $media->{eltorito_legacy} = 1;
+      $media->{eltorito_efi} = 1;
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/initrd";
@@ -1169,6 +1223,8 @@ sub get_expected_media_layout
       $media->{kernel} = "boot/s390x/linux";
       $media->{cd_ikr} = "boot/s390x/cd.ikr";
       $media->{suse_ins} = "boot/s390x/suse.ins";
+      $media->{eltorito_legacy} = 1;
+      $media->{eltorito_s390x} = 1;
     }
     elsif($arch eq 'x86_64') {
       $media->{isolinux_cfg} = "boot/x86_64/loader/isolinux.cfg";
@@ -1179,6 +1235,8 @@ sub get_expected_media_layout
       $media->{efi_loader} = "EFI/BOOT/bootx64.efi";
       $media->{efi_grub_cfg} = "EFI/BOOT/grub.cfg";
       $media->{hybrid_mode} = 'efi';
+      $media->{eltorito_legacy} = 1;
+      $media->{eltorito_efi} = 1;
     }
   }
   elsif($media->{variant} eq 'live') {
@@ -1194,6 +1252,7 @@ sub get_expected_media_layout
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
       $media->{hybrid_mode} = 'efi';
+      $media->{eltorito_efi} = 1;
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/initrd";
@@ -1210,6 +1269,7 @@ sub get_expected_media_layout
       $media->{kernel} = "boot/s390x/linux";
       $media->{cd_ikr} = "boot/s390x/cd.ikr";
       $media->{suse_ins} = "boot/s390x/suse.ins";
+      $media->{eltorito_s390x} = 1;
     }
     elsif($arch eq 'x86_64') {
       $media->{grub_cfg} = "boot/grub2/grub.cfg";
@@ -1223,6 +1283,8 @@ sub get_expected_media_layout
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
       $media->{hybrid_mode} = 'efi';
+      $media->{eltorito_legacy} = 1;
+      $media->{eltorito_efi} = 1;
     }
   }
   elsif($media->{variant} eq 'selfinstall') {
@@ -1238,6 +1300,7 @@ sub get_expected_media_layout
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
       $media->{hybrid_mode} = 'efi';
+      $media->{eltorito_efi} = 1;
     }
     elsif($arch eq 'ppc64le') {
       $media->{initrd} = "boot/ppc64le/loader/initrd";
@@ -1254,6 +1317,7 @@ sub get_expected_media_layout
       $media->{kernel} = "boot/s390x/linux";
       $media->{cd_ikr} = "boot/s390x/cd.ikr";
       $media->{suse_ins} = "boot/s390x/suse.ins";
+      $media->{eltorito_s390x} = 1;
     }
     elsif($arch eq 'x86_64') {
       $media->{grub_cfg} = "boot/grub2/grub.cfg";
@@ -1267,6 +1331,8 @@ sub get_expected_media_layout
       chomp(my $id = read_file "boot/mbrid");
       $media->{grub_search_id} = "/boot/$id" if is_file "boot/$id";
       $media->{hybrid_mode} = 'efi';
+      $media->{eltorito_legacy} = 1;
+      $media->{eltorito_efi} = 1;
     }
   }
 }

--- a/verifymedia
+++ b/verifymedia
@@ -456,7 +456,8 @@ show
   "has tag pointing to signature block",
   "To be able to sign media, there must be a 'signature' entry in media tag data\n(check with 'tagmedia --show').";
 
-show
+show_conditional
+  $media->{expect_signature_file},
   $sig->{file_ok} ? 1 : 2,
   "has .signature file",
   "
@@ -466,7 +467,7 @@ show
   ";
 
 show_conditional
-  $sig->{file_ok},
+  $media->{expect_signature_file} && $sig->{file_ok},
   $sig->{block_is_file},
   "signature block and .signature file are identical",
   "If there is a '.signature' file, the 'signature' tag must point to it.";
@@ -1039,6 +1040,8 @@ sub get_expected_media_layout
     }
   }
   elsif($media->{variant} eq 'live') {
+    $media->{expect_signature_file} = 1;
+
     if($arch eq 'aarch64') {
       $media->{grub_cfg} = "boot/grub2/grub.cfg";
       $media->{initrd} = "boot/aarch64/loader/initrd";
@@ -1078,6 +1081,8 @@ sub get_expected_media_layout
     }
   }
   elsif($media->{variant} eq 'selfinstall') {
+    $media->{expect_signature_file} = 1;
+
     if($arch eq 'aarch64') {
       $media->{grub_cfg} = "boot/grub2/grub.cfg";
       $media->{initrd} = "boot/aarch64/loader/initrd";

--- a/verifymedia_man.adoc
+++ b/verifymedia_man.adoc
@@ -1,0 +1,48 @@
+= verifymedia(1)
+:doctype: manpage
+:manmanual: User Commands
+:mansource: verifymedia {version}
+
+== Name
+
+verifymedia - Verfiy SUSE installation or Live ISO images.
+
+
+== Synopsis
+
+*verifymedia* _ISO_
+
+
+== Description
+
+verifymedia checks SUSE bootable installation or Live media for technical correctness.
+
+
+=== General Options
+
+*--ignore*=_TOPIC_LIST_::
+Ignore specific test results. The test is still run but any failures are not counted.
+TOPIC_LIST are a list of test topics as shown in the test report.
+
+*--verbose*::
+Show more detailed messages. Can be repeated to log even more.
+
+*--version*::
+Show mksusecd version.
+
+*--save-temp*::
+Keep temporary files.
+
+*--help*::
+Show this help text.
+
+== See Also
+
+*mksusecd*(1), *checkmedia*(1), *tagmedia*(1).
+
+== Links
+
+- more documentation: `/usr/share/doc/packages/mksusecd` +
+- get latest version: https://github.com/openSUSE/mksusecd?tab=readme-ov-file#downloads +
+- mksusecd web site: https://github.com/openSUSE/mksusecd +
+- openSUSE Build Service: https://build.opensuse.org


### PR DESCRIPTION
## Task

Create script that verifies correctness of SUSE (installation) media.

## Sample output

```
# verifymedia agama-installer.x86_64-11.0.0-SLE-Beta1.iso
Verifying: agama-installer.x86_64-11.0.0-SLE-Beta1.iso
[✔] image has ISO-9660 file system
[✔] image uses Rock Ridge extension
[✔] image uses Joliet extension
[✔] image has volume id
[✔] all files are world-readable
[✔] all files are owned by root
[✔] media style: suse
[✔] media variant: live
[✔] media architecture: aarch64
[✔] media layout supported
[✔] kernel exists
[✔] initrd exists
[✔] grub config exists
[✘] grub config references correct root file system
  boot/0x11cebed2
  'boot/grub2/grub.cfg' searches for 'boot/0x11cebed2' to identify its root file system.
  This file must exist.
[✔] UEFI grub config exists
[✔] UEFI grub config references correct root file system
[✔] UEFI boot loader exists
[!] UEFI boot image exists
  boot/aarch64/loader/efiboot.img
  UEFI boot image should exist and have non-zero size.
[✔] ISO label matches dracut live 'root' option
[✔] no garbage files
[✔] has tag pointing to signature block
[✔] has .signature file
[✔] signature block and .signature file are identical
[✔] ISO has sha256 digest
[✔] ISO is signed
```