### PR TITLE
add missing perl-JSON dependency

### DIFF
--- a/obs/mksusecd.spec
+++ b/obs/mksusecd.spec
@@ -48,6 +48,7 @@ Requires:       gpg2
 Requires:       mtools
 Requires:       squashfs
 Requires:       xz
+Requires:       perl-JSON
 BuildRequires:  pkgconfig(blkid)
 BuildRequires:  pkgconfig(uuid)
 BuildRequires:  pkgconfig(json-c)

--- a/verifymedia
+++ b/verifymedia
@@ -552,9 +552,15 @@ $media->{signature} = $sig if $sig;
 print "- signature data:\n", Dumper($media->{signature}) if $media->{signature} && $opt_verbose >= 2;
 
 show
-  $sig->{block_ok},
-  "has tag pointing to signature block",
-  "To be able to sign media, there must be a 'signature' entry in media tag data\n(check settings with 'tagmedia --show').";
+  $sig->{block_digest},
+  "ISO has digest",
+  "There must be a digest stored in media tag data. Ideally sha256 or sha512.\n(check settings with 'tagmedia --show').";
+
+show_conditional
+  $sig->{block_digest},
+  $sig->{block_digest} eq 'sha256' || $sig->{block_digest} eq 'sha512',
+  "ISO digest is $sig->{block_digest}",
+  "Prefer a secure digest like sha256 or sha512.\n(check settings with 'tagmedia --show').";
 
 show_conditional
   $media->{expect_signature_file},
@@ -573,15 +579,9 @@ show_conditional
   "If there is a '.signature' file, the 'signature' tag must point to it.";
 
 show
-  $sig->{block_digest},
-  "ISO has digest",
-  "There must be a digest stored in media tag data. Ideally sha256 or sha512.\n(check settings with 'tagmedia --show').";
-
-show_conditional
-  $sig->{block_digest},
-  $sig->{block_digest} eq 'sha256' || $sig->{block_digest} eq 'sha512',
-  "ISO digest is $sig->{block_digest}",
-  "Prefer a secure digest like sha256 or sha512.\n(check settings with 'tagmedia --show').";
+  $sig->{block_ok},
+  "ISO is ready to be signed",
+  "To be able to sign media, there must be a 'signature' entry in media tag data\npointing to a signature block (check settings with 'tagmedia --show').";
 
 show
   $sig->{block_signed},

--- a/verifymedia
+++ b/verifymedia
@@ -221,7 +221,7 @@ my $initrd_dir;
 Getopt::Long::Configure("gnu_compat");
 
 GetOptions(
-  'ignore=s{1,}'     => \@$opt_ignore_list,
+  'ignore=s'         => \@$opt_ignore_list,
   'save-temp'        => \$opt_save_temp,
   'verbose|v'        => sub { $opt_verbose++ },
   'version'          => sub { print "$VERSION\n"; exit 0 },
@@ -605,8 +605,8 @@ sub usage
 Usage: verifymedia ISO
 Verify SUSE installation media.
 
-      --ignore TOPIC_LIST         Ignore specific test results. The test is still run but any failures
-                                  are not counted.
+      --ignore TOPIC              Ignore specific test results. The test is still run but any failures
+                                  are not counted. The option can be repeated to exclude several tests.
       --verbose                   Increase log level.
       --version                   Show verifymedia version.
       --save-temp                 Keep temporary files.

--- a/verifymedia_man.adoc
+++ b/verifymedia_man.adoc
@@ -20,9 +20,10 @@ verifymedia checks SUSE bootable installation or Live media for technical correc
 
 === General Options
 
-*--ignore*=_TOPIC_LIST_::
-Ignore specific test results. The test is still run but any failures are not counted.
-TOPIC_LIST are a list of test topics as shown in the test report.
+*--ignore*=_TOPIC_::
+Ignore specific test result. The test is still run but any failures are not counted.
+TOPIC is the test topic as shown in the test report.
+The option can be repeated to exclude several tests.
 
 *--verbose*::
 Show more detailed messages. Can be repeated to log even more.


### PR DESCRIPTION
## Task

- verifymedia depends on perl-JSON
- rework signature test wording to be more clear
- `--ignore` takes` only single argument

## Example

```
# verifymedia SLE-15-SP5-Online-x86_64-QU1-Media1.iso
Verifying: SLE-15-SP5-Online-x86_64-QU1-Media1.iso
Check results: [✔] = ok, [✘] = bad, [!] = not ideal
[✔] image has ISO-9660 file system
[✔] image uses Rock Ridge extension
[✔] image uses Joliet extension
[✔] image has volume id
[✔] all files are world-readable
[✔] all files are owned by root
[✔] media style: suse
[✔] media variant: install
[✔] media architecture: x86_64
[✔] media layout supported
[✔] .treeinfo architecture matches
[✔] kernel and initrd referenced in .treeinfo exist
[✔] kernel exists
[✔] initrd exists
[✔] isolinux config exists
[✔] UEFI grub config exists
[✔] UEFI grub config references correct root file system
[✔] UEFI boot loader exists
[✔] UEFI boot image exists
[✔] no garbage files
[✔] has MBR or GPT partition table
[✔] has boot partition with VFAT file system
[✔] boot partition is EFI System Partition
[✔] has partition pointing to ISO image data
[✔] no invalid partition entries
[✔] El Torito legacy bootable
[✔] El Torito UEFI bootable
[✔] ISO has digest
[✔] ISO digest is sha256
[✔] ISO is ready to be signed
[✔] ISO is signed
```