### PR TITLE
support dracut-style initrd (uncompressed cpio archive followed by compressed cpio archive) (bsc#1239528)

### DIFF
--- a/mksusecd
+++ b/mksusecd
@@ -204,6 +204,7 @@ sub create_sign_key;
 sub add_sign_key;
 sub sign_content_or_checksums;
 sub file_magic;
+sub fs_type;
 sub get_archive_type;
 sub unpack_cpiox;
 sub unpack_archive;
@@ -2846,7 +2847,8 @@ sub get_initrd_format
 
   if(my $x = get_kernel_initrd) {
     my $c = get_archive_type fname($x->{initrd});
-    if($c =~ /\.(gz|xz|zst)$/) {
+    print "initrd format: $c\n" if $opt_verbose >= 1;
+    if($c =~ /\.(gz|xz|zst)($|\.\[)/) {
       if($f) {
         die "differing initrd formats: $f & $1\n" if $1 ne $f;
       }
@@ -2860,7 +2862,7 @@ sub get_initrd_format
     }
   }
 
-  # print "initrd format: $f\n";
+  print "initrd compression type: $f\n" if $opt_verbose >= 1;
 
   $initrd_format = $f;
 }
@@ -4224,12 +4226,77 @@ sub file_magic
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# result = fs_type(file, pipe, offset)
+#
+# -   file: the input file, or '-' if pipe is set
+# -   pipe: (if set) the command to read from
+# - offset: probe at offset
+# - result: type hash
+#
+sub fs_type
+{
+  my $file = $_[0];
+  my $pipe = $_[1];
+  my $offset = $_[2] || 0;
+  my $type = { };
+
+  if($pipe) {
+    if(open my $fd, "$pipe |") {
+      my $buf;
+      # 1 MiB seems to be the minimum for blkid to work
+      my $i = read $fd, $buf, 1024*1024;
+      close $fd;
+      $file = $tmp->file();
+      if(open my $fd, ">", $file) {
+        syswrite $fd, $buf;
+        close $fd;
+      }
+      else {
+        undef $file;
+      }
+    }
+  }
+
+  if($file) {
+    my $blkid = `blkid --offset '$offset' -p '$file' 2>/dev/null`;
+    if($blkid =~ /\bUSAGE="filesystem"/ && $blkid =~ /\bTYPE="([^"]*)"/) {
+      $type->{fs} = $1;
+    }
+
+    if($blkid =~ /\bUSAGE="crypto"/ && $blkid =~ /\bTYPE="([^"]*)"/) {
+      $type->{crypto} = $1;
+    }
+
+    my $parti = `parti --json $file 2>/dev/null`;
+    $parti = decode_json($parti) if $parti;
+
+    if($parti->{gpt_primary}) {
+      $type->{gpt} = $parti->{gpt_primary};
+    }
+    elsif($parti->{mbr}) {
+      $type->{mbr} = $parti->{mbr};
+    }
+    $type->{eltorito} = $parti->{eltorito} if $parti->{eltorito};
+  }
+
+  return $type;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Get archive type;
 #
 # type = get_archive_type(file)
 #
 # - file: the archive name
 # - type: something like 'tar.xz' or undef if the archive is unsupported.
+#
+# The special type '[start:length]' designates a part of the file of 'length' bytes
+# beginning at 'start'. A 'length' of 0 means 'to the end of file'.
+#
+# type can ba a comma-separated list of individual types. Which makes only sense in
+# relation to types containing '[start:length]' to indicate that different parts of
+# a file can have different archive types.
 #
 sub get_archive_type
 {
@@ -4243,13 +4310,15 @@ sub get_archive_type
     return 'dir';
   }
 
-  if(! -f $file) {
+  if(! (-f $file || -b _)) {
     return undef;
   }
 
   if(! -r $file) {
     die "$orig: not readable; you need root privileges.\n";
   }
+
+  my @types_found;
 
   do {
     my $t = file_magic $file, $cmd;
@@ -4259,11 +4328,27 @@ sub get_archive_type
     }
     elsif($t =~ /^ASCII cpio archive \(SVR4/) {
       $type = "cpiox$type";
+      if(!$cmd) {
+        my $cpiox_stats = unpack_cpiox undef, $file;
+        my $len = $cpiox_stats ? $cpiox_stats->{bytes} : 0;
+        if($len < -s $file) {
+          push @types_found, "$type.[0:$len]";
+          $type = ".[$len:]";
+          $cmd = "dd status=none bs=$len skip=1 if='$file' 2>/dev/null";
+          $file = "-";
+        }
+      }
     }
-    elsif($t =~ /\b(cpio|tar) archive/) {
-      $type = "$1$type";
+    elsif($t =~ /\b(cpio|tar|rar) archive/i) {
+      $type = "\L$1\E$type";
     }
-    elsif($t =~ /^(gzip|XZ|Zstandard) compressed data/) {
+    elsif($t =~ / QCOW /) {
+      $type = "qcow$type";
+    }
+    elsif($t =~ /Zip archive data|Zip data|EPUB /) {
+      $type = "zip$type";
+    }
+    elsif($t =~ /^(bzip2|gzip|XZ|Zstandard) compressed data/) {
       my $c = "\L$1";
       $c =~ s/zstandard/zstd/;
       if($cmd) {
@@ -4273,14 +4358,81 @@ sub get_archive_type
         $cmd = "$c --quiet -dc '$file'";
       }
       $file = "-";
+      $c =~ s/bzip2/bz2/;
       $c =~ s/gzip/gz/;
       $c =~ s/zstd/zst/;
       $type = ".$c$type";
     }
     else {
-      die "$orig: unsupported archive format\n";
+      my $type_added = 0;
+      my $fs_type = fs_type $file, $cmd;
+      my $saved_type = $type;
+
+      if($fs_type->{fs}) {
+        $type = "fs_$fs_type->{fs}$saved_type";
+        $type_added = 1;
+      }
+
+      if($fs_type->{crypto}) {
+        $type = "$fs_type->{crypto}$saved_type";
+        $type_added = 1;
+      }
+
+      if($saved_type !~ /,/) {
+        if($fs_type->{gpt}) {
+          for my $p (@{$fs_type->{gpt}{partitions}}) {
+            if($p->{size}) {
+              my $start = $p->{first_lba} * $fs_type->{gpt}{block_size};
+              my $size = $p->{size} * $fs_type->{gpt}{block_size};
+              my $fs_type2 = fs_type $file, $cmd, $start;
+              my $fs2 = "fs_$fs_type2->{fs}" if $fs_type2->{fs};
+              $fs2 ||= $fs_type2->{crypto};
+              $fs2 .= "." if $fs2 ne "";
+              $type .= ",${fs2}part$p->{number}.[$start:$size]$saved_type";
+              $type_added = 1;
+            }
+          }
+        }
+        if($fs_type->{mbr}) {
+          for my $p (@{$fs_type->{mbr}{partitions}}) {
+            if($p->{size}) {
+              my $start = $p->{first_lba} * $fs_type->{mbr}{block_size};
+              my $size = $p->{size} * $fs_type->{mbr}{block_size};
+              my $fs_type2 = fs_type $file, $cmd, $start;
+              my $fs2 = "fs_$fs_type2->{fs}" if $fs_type2->{fs};
+              $fs2 ||= $fs_type2->{crypto};
+              $fs2 .= "." if $fs2 ne "";
+              $type .= ",${fs2}part$p->{number}.[$start:$size]$saved_type";
+              $type_added = 1;
+            }
+          }
+        }
+        if($fs_type->{eltorito}) {
+          my $number = 1;
+          for my $p (@{$fs_type->{eltorito}{catalog}}) {
+            if($p->{size}) {
+              my $start = $p->{first_lba} * $fs_type->{mbr}{block_size};
+              my $size = $p->{size} * $fs_type->{mbr}{block_size};
+              my $fs_type2 = fs_type $file, $cmd, $start;
+              my $fs2 = "fs_$fs_type2->{fs}" if $fs_type2->{fs};
+              $fs2 ||= $fs_type2->{crypto};
+              $fs2 .= "." if $fs2 ne "";
+              $type .= ",${fs2}eltorito$number.[$start:$size]$saved_type";
+              $type_added = 1;
+            }
+            $number++ if $p->{boot};
+          }
+        }
+      }
+
+      $type =~ s/^,?//;
+
+      return undef if !$type_added;
     }
   } while($type =~ /^\./);
+
+  push @types_found, $type;
+  $type = join ",", @types_found;
 
   # print "$file = $type\n";
 
@@ -4296,9 +4448,18 @@ sub get_archive_type
 #
 # unpack_cpiox(dst, file, part)
 #
-# -  dst: the directory to unpack to
+# -  dst: the directory to unpack to; if dst is undef, don't unpack anything (just parse)
 # - file: the archive file name
 # - part: the part number (1 based) of a multipart archive (0 = unpack all)
+#
+# If dst is undef, write nothing.
+#
+# Return hash with two elements:
+#   - bytes = size of cpiox archive (data actually read)
+#   - parts = number of individual cpiox archives parsed
+#
+# If 'part' is != 0, 'bytes' is the end of that part (right after the 'TRAILER!!!' entry).
+# If 'part' is 0, 'bytes' is the end of valid cpiox data + any trailing 0 bytes.
 #
 sub unpack_cpiox
 {
@@ -4322,6 +4483,9 @@ sub unpack_cpiox
 
   # track # of written bytes (reset at start of each cpio archive)
   my $write_ofs;
+
+  # track # of read bytes
+  my $read_ofs;
 
   # Read # of bytes from input and write to output.
   #
@@ -4352,7 +4516,8 @@ sub unpack_cpiox
     # Actually this only looks for the next non-zero data blob.
     if($sync) {
       $sync = 0;
-      while(sysread($f, $buf, 1) == 1 && $buf eq "\x00") {};
+      while(sysread($f, $buf, 1) == 1 && $buf eq "\x00") { $read_ofs++ };
+      $read_ofs += length $buf;
       $len -= length $buf;
     }
 
@@ -4360,6 +4525,7 @@ sub unpack_cpiox
     while($len) {
       my $x = sysread $f, substr($buf, length $buf), $len;
       last if !$x;
+      $read_ofs += $x;
       $len -= $x;
     };
 
@@ -4367,7 +4533,7 @@ sub unpack_cpiox
     if(length $buf) {
       # Open a new pipe if needed.
       # But only if part number matches or is 0 (== all parts).
-      if(!$p && ($part == 0 || $part == $cnt)) {
+      if($dst && !$p && ($part == 0 || $part == $cnt)) {
         open $p, "| ( cd $dst ; $cpio_cmd )" or die "failed to open cpio: $!\n";
         $write_ofs = 0;
       }
@@ -4413,10 +4579,14 @@ sub unpack_cpiox
       my $magic = substr($buf, 0, 6);
       my $head = substr($buf, 6);
 
+      if($magic !~ /^07070[12]$/) {
+        close $f;
+        return { bytes => $read_ofs - $len, parts => $cnt - 1 } if !$dst;
+        die "broken cpio header\n";
+      }
+
       my $fname_len = hex substr $buf, 94, 8;
       my $data_len = hex substr $buf, 54, 8;
-
-      die "broken cpio header\n" if $magic !~ /^07070[12]$/;
 
       $fname_len += (2, 1, 0, 3)[$fname_len & 3];
       $data_len = (($data_len + 3) & ~3);
@@ -4439,7 +4609,7 @@ sub unpack_cpiox
         # exit if we're done
         if($cnt++ == $part) {
           close $f;
-          return;
+          return { bytes => $read_ofs, parts => $part };
         }
       }
     }
@@ -4457,6 +4627,8 @@ sub unpack_cpiox
   else {
     die "error reading cpio archive: $!\n";
   }
+
+  return { bytes => $read_ofs, parts => $cnt - 1 };
 }
 
 
@@ -4470,6 +4642,12 @@ sub unpack_cpiox
 # -  dir: the directory to unpack to
 # - part: is the part number of a multipart archive (0 = unpack all)
 #
+# Sample type strings:
+#
+#   "dir", "tar", "tar.gz", "tar.gz.xz", "cpiox.[0:1024],cpiox.xz.gz.[1024:]"
+#
+# Type string is a comma-separated list of individual sub_types.
+#
 sub unpack_archive
 {
   my $type = $_[0];
@@ -4477,73 +4655,120 @@ sub unpack_archive
   my $dir = $_[2];
   my $part = $_[3];
 
-  return undef if $type eq '';
+  for my $sub_type (split /,/, $type) {
+    next if $sub_type eq '';
 
-  my $cmd;
-  my $cpiox;
+    my $cmd;
+    my $cpiox;
 
-  if($type eq 'dir') {
-    $cmd = "tar -C '$file' -cf - .";
-    $type = 'tar';
-  }
-  elsif(! -r $file) {
-    die "$file: not readable; you need root privileges.\n";
-  }
+    if($sub_type eq 'dir') {
+      $cmd = "tar -C '$file' -cf - .";
+      $sub_type = 'tar';
+    }
+    elsif(! -r $file) {
+      die "$file: not readable; you need root privileges.\n";
+    }
 
-  for (reverse split /\./, $type) {
-    if(/^(gz|xz|zst|rpm)$/) {
-      my $c;
-      if($1 eq 'gz') {
-        $c = 'gzip --quiet -dc';
+    for (reverse split /\./, $sub_type) {
+      if(/^(gz|xz|zst|rpm)$/) {
+        my $c;
+        if($1 eq 'gz') {
+          $c = 'gzip --quiet -dc';
+        }
+        elsif($1 eq 'xz') {
+          $c = 'xz --quiet -dc';
+        }
+        elsif($1 eq 'zst') {
+          $c = 'zstd --quiet -dc';
+        }
+        elsif($1 eq 'bz2') {
+          $c = 'bzip2 --quiet -dc';
+        }
+        else {
+          $c = 'rpm2cpio';
+        }
+        if($cmd) {
+          $cmd .= " | $c";
+        }
+        else {
+          $cmd = "$c '$file'";
+        }
       }
-      elsif($1 eq 'xz') {
-        $c = 'xz --quiet -dc';
+      elsif(/\[(.*):(.*)\]/) {
+        my $start = ($1 ne "" ? $1 : 0) + 0;
+        my $len = ($2 ne "" ? $2 : 0) + 0;
+        my $args;
+        $args = sprintf "bs=1 skip=%d count=%d", $start, $len;
+        $args = "bs=$start skip=1" if $start && !$len;
+        $args = "bs=$len count=1" if !$start && $len;
+        if($cmd) {
+          $cmd .= " | dd status=none $args 2>/dev/null";
+        }
+        else {
+          $cmd = "dd status=none $args if='$file' 2>/dev/null";
+        }
       }
-      elsif($1 eq 'zst') {
-        $c = 'zstd --quiet -dc';
+      elsif($_ eq 'tar') {
+        $cmd = "cat '$file'" if !$cmd;
+        $cmd .= " | tar -C '$dir' --keep-directory-symlink -xpf - 2>/dev/null";
+        last;
       }
-      else {
-        $c = 'rpm2cpio';
+      elsif($_ eq 'zip') {
+        if(!$cmd) {
+          $cmd = "unzip -qX '$file' -d '$dir'";
+        }
+        else {
+          my $t = $tmp->file();
+          $cmd .=  " > '$t' ; unzip -qX '$t' -d '$dir'";
+        }
+        last;
       }
-      if($cmd) {
-        $cmd .= " | $c";
+      elsif($_ eq 'rar') {
+        my $abs_file = abs_path $file;
+        if(!$cmd) {
+          $cmd = "cd '$dir' ; unrar x -idq '$abs_file'";
+        }
+        else {
+          my $t = $tmp->file();
+          $cmd .=  " > '$t' ; cd '$dir' ; unrar x -idq '$abs_file'";
+        }
+        last;
       }
-      else {
-        $cmd = "$c '$file'";
+      elsif($_ eq 'cpio') {
+        $cmd = "cat '$file'" if !$cmd;
+        $cmd .= " | ( cd '$dir' ; cpio --quiet -dmiu --sparse --no-absolute-filenames 2>/dev/null )";
+        last;
+      }
+      elsif($_ eq 'cpiox') {
+        if(!$cmd) {
+          $cmd = $file;
+        }
+        else {
+          $cmd .= " |";
+        }
+        $cpiox = 1;
+        last;
       }
     }
-    elsif($_ eq 'tar') {
-      $cmd = "cat '$file'" if !$cmd;
-      $cmd .= " | tar -C '$dir' --keep-directory-symlink -xpf - 2>/dev/null";
-      last;
-    }
-    elsif($_ eq 'cpio') {
-      $cmd = "cat '$file'" if !$cmd;
-      $cmd .= " | ( cd '$dir' ; cpio --quiet -dmiu --sparse --no-absolute-filenames 2>/dev/null )";
-      last;
-    }
-    elsif($_ eq 'cpiox') {
-      if(!$cmd) {
-        $cmd = $file;
-      }
-      else {
-        $cmd .= " |";
-      }
-      $cpiox = 1;
-      last;
-    }
-  }
 
-  # cpiox = concatenated compressed cpio archives as the kernel uses for initrd
-  # must be SVR4 ASCII format, with or without CRC ('cpio -H newc')
-  # in this case we have to parse the cpio stream and handle the 'TRAILER!!!' entries
-  if($cpiox) {
-    # print STDERR "unpack_cpiox($cmd)\n";
-    unpack_cpiox $dir, $cmd, $part;
-  }
-  else {
-    # print STDERR "$cmd\n";
-    system $cmd;
+    # cpiox = concatenated compressed cpio archives as the kernel uses for initrd
+    # must be SVR4 ASCII format, with or without CRC ('cpio -H newc')
+    # in this case we have to parse the cpio stream and handle the 'TRAILER!!!' entries
+    if($cpiox) {
+      print "unpack_cpiox($cmd)\n" if $opt_verbose >= 2;
+      my $cpiox_stats = unpack_cpiox $dir, $cmd, $part;
+      if($cpiox_stats && $part) {
+        $part -= $cpiox_stats->{parts};
+        $part = -1 if !$part;		# 0 has special meaning
+      }
+    }
+    elsif($cmd ne "") {
+      print "$cmd\n" if $opt_verbose >= 2;
+      system $cmd;
+    }
+    else {
+      die "$file: cannot unpack archive ($type)\n";
+    }
   }
 }
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1239528

So far only either entirely uncompressed or compressed multi-part initrds were supported.